### PR TITLE
API refactors: pass Window to AppWindow and introduce WindowHandle

### DIFF
--- a/examples/open_window.rs
+++ b/examples/open_window.rs
@@ -1,5 +1,3 @@
-use std::sync::mpsc;
-
 use baseview::{Event, Window, WindowHandler};
 
 fn main() {
@@ -10,11 +8,7 @@ fn main() {
         parent: baseview::Parent::None,
     };
 
-    let (_app_message_tx, app_message_rx) = mpsc::channel::<()>();
-
-    // Send _app_message_tx to a separate thread, then send messages to the GUI thread.
-
-    let _ = Window::open::<MyProgram>(window_open_options, app_message_rx);
+    Window::open::<MyProgram>(window_open_options);
 }
 
 struct MyProgram {}

--- a/examples/open_window.rs
+++ b/examples/open_window.rs
@@ -8,7 +8,7 @@ fn main() {
         parent: baseview::Parent::None,
     };
 
-    Window::open::<MyProgram>(window_open_options);
+    let _handle = Window::open::<MyProgram>(window_open_options);
 }
 
 struct MyProgram {}

--- a/examples/open_window.rs
+++ b/examples/open_window.rs
@@ -1,6 +1,6 @@
 use std::sync::mpsc;
 
-use baseview::Event;
+use baseview::{Event, Window};
 
 fn main() {
     let window_open_options = baseview::WindowOpenOptions {
@@ -14,21 +14,21 @@ fn main() {
 
     // Send _app_message_tx to a separate thread, then send messages to the GUI thread.
 
-    let _ = baseview::Window::<MyProgram>::open(window_open_options, app_message_rx);
+    let _ = Window::open::<MyProgram>(window_open_options, app_message_rx);
 }
+
 struct MyProgram {}
 
 impl baseview::AppWindow for MyProgram {
     type AppMessage = ();
 
-    fn build(_window_handle: baseview::RawWindow, window_info: &baseview::WindowInfo) -> Self {
-        println!("Window info: {:?}", window_info);
+    fn build(window: &mut Window) -> Self {
         Self {}
     }
 
-    fn draw(&mut self) {}
+    fn draw(&mut self, window: &mut Window) {}
 
-    fn on_event(&mut self, event: Event) {
+    fn on_event(&mut self, window: &mut Window, event: Event) {
         match event {
             Event::CursorMotion(x, y) => {
                 println!("Cursor moved, x: {}, y: {}", x, y);
@@ -69,5 +69,5 @@ impl baseview::AppWindow for MyProgram {
         }
     }
 
-    fn on_app_message(&mut self, _message: Self::AppMessage) {}
+    fn on_app_message(&mut self, window: &mut Window, _message: Self::AppMessage) {}
 }

--- a/examples/open_window.rs
+++ b/examples/open_window.rs
@@ -1,6 +1,6 @@
 use std::sync::mpsc;
 
-use baseview::{Event, Window};
+use baseview::{Event, Window, WindowHandler};
 
 fn main() {
     let window_open_options = baseview::WindowOpenOptions {
@@ -19,8 +19,8 @@ fn main() {
 
 struct MyProgram {}
 
-impl baseview::AppWindow for MyProgram {
-    type AppMessage = ();
+impl WindowHandler for MyProgram {
+    type Message = ();
 
     fn build(window: &mut Window) -> Self {
         Self {}
@@ -69,5 +69,5 @@ impl baseview::AppWindow for MyProgram {
         }
     }
 
-    fn on_app_message(&mut self, window: &mut Window, _message: Self::AppMessage) {}
+    fn on_message(&mut self, window: &mut Window, _message: Self::Message) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,21 +36,9 @@ pub struct WindowOpenOptions<'a> {
 pub trait AppWindow {
     type AppMessage;
 
-    fn build(window_handle: RawWindow, window_info: &WindowInfo) -> Self;
+    fn build(window: &mut Window) -> Self;
 
-    fn draw(&mut self);
-    fn on_event(&mut self, event: Event);
-    fn on_app_message(&mut self, message: Self::AppMessage);
-}
-
-/// A wrapper for a `RawWindowHandle`. Some context creators expect an `&impl HasRawWindowHandle`.
-#[derive(Debug, Copy, Clone)]
-pub struct RawWindow {
-    pub raw_window_handle: raw_window_handle::RawWindowHandle,
-}
-
-unsafe impl raw_window_handle::HasRawWindowHandle for RawWindow {
-    fn raw_window_handle(&self) -> raw_window_handle::RawWindowHandle {
-        self.raw_window_handle
-    }
+    fn draw(&mut self, window: &mut Window);
+    fn on_event(&mut self, window: &mut Window, event: Event);
+    fn on_app_message(&mut self, window: &mut Window, message: Self::AppMessage);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,12 +33,12 @@ pub struct WindowOpenOptions<'a> {
     pub parent: Parent,
 }
 
-pub trait AppWindow {
-    type AppMessage;
+pub trait WindowHandler {
+    type Message;
 
     fn build(window: &mut Window) -> Self;
 
     fn draw(&mut self, window: &mut Window);
     fn on_event(&mut self, window: &mut Window, event: Event);
-    fn on_app_message(&mut self, window: &mut Window, message: Self::AppMessage);
+    fn on_message(&mut self, window: &mut Window, message: Self::Message);
 }

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -6,22 +6,23 @@ use cocoa::appkit::{
     NSApplicationActivationPolicyRegular, NSBackingStoreBuffered, NSRunningApplication, NSView,
     NSWindow, NSWindowStyleMask,
 };
-use cocoa::base::{nil, NO};
+use cocoa::base::{id, nil, NO};
 use cocoa::foundation::{NSAutoreleasePool, NSPoint, NSRect, NSSize, NSString};
 
 use raw_window_handle::{macos::MacOSHandle, HasRawWindowHandle, RawWindowHandle};
 
-use crate::{
-    AppWindow, Event, MouseButtonID, MouseScroll, RawWindow, WindowInfo, WindowOpenOptions,
-};
+use crate::{AppWindow, MouseScroll, WindowOpenOptions};
 
-pub struct Window<A: AppWindow> {
-    app_window: A,
-    app_message_rx: mpsc::Receiver<A::AppMessage>,
+pub struct Window {
+    ns_window: id,
+    ns_view: id,
 }
 
-impl<A: AppWindow> Window<A> {
-    pub fn open(options: WindowOpenOptions, app_message_rx: mpsc::Receiver<A::AppMessage>) -> Self {
+impl Window {
+    pub fn open<A: AppWindow>(
+        options: WindowOpenOptions,
+        app_message_rx: mpsc::Receiver<A::AppMessage>,
+    ) {
         unsafe {
             let _pool = NSAutoreleasePool::new(nil);
 
@@ -33,7 +34,7 @@ impl<A: AppWindow> Window<A> {
                 NSSize::new(options.width as f64, options.height as f64),
             );
 
-            let window = NSWindow::alloc(nil)
+            let ns_window = NSWindow::alloc(nil)
                 .initWithContentRect_styleMask_backing_defer_(
                     rect,
                     NSWindowStyleMask::NSTitledWindowMask,
@@ -41,37 +42,33 @@ impl<A: AppWindow> Window<A> {
                     NO,
                 )
                 .autorelease();
-            window.center();
-            window.setTitle_(NSString::alloc(nil).init_str(options.title));
-            window.makeKeyAndOrderFront_(nil);
+            ns_window.center();
+            ns_window.setTitle_(NSString::alloc(nil).init_str(options.title));
+            ns_window.makeKeyAndOrderFront_(nil);
 
-            let view = NSView::alloc(nil).init();
-            window.setContentView_(view);
+            let ns_view = NSView::alloc(nil).init();
+            ns_window.setContentView_(ns_view);
 
-            let raw_window = RawWindow {
-                raw_window_handle: RawWindowHandle::MacOS(MacOSHandle {
-                    ns_window: window as *mut c_void,
-                    ns_view: app as *mut c_void,
-                    ..raw_window_handle::macos::MacOSHandle::empty()
-                }),
+            let mut window = Window {
+                ns_window,
+                ns_view,
             };
 
-            let window_info = WindowInfo {
-                width: options.width as u32,
-                height: options.height as u32,
-                scale: 1.0,
-            };
-
-            let app_window = A::build(raw_window, &window_info);
+            let app_window = A::build(&mut window);
 
             let current_app = NSRunningApplication::currentApplication(nil);
             current_app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps);
             app.run();
-
-            Window {
-                app_window,
-                app_message_rx,
-            }
         }
+    }
+}
+
+unsafe impl HasRawWindowHandle for Window {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        RawWindowHandle::MacOS(MacOSHandle {
+            ns_window: self.ns_window as *mut c_void,
+            ns_view: self.ns_view as *mut c_void,
+            ..MacOSHandle::empty()
+        })
     }
 }

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -11,7 +11,7 @@ use cocoa::foundation::{NSAutoreleasePool, NSPoint, NSRect, NSSize, NSString};
 
 use raw_window_handle::{macos::MacOSHandle, HasRawWindowHandle, RawWindowHandle};
 
-use crate::{AppWindow, MouseScroll, WindowOpenOptions};
+use crate::{MouseScroll, WindowHandler, WindowOpenOptions};
 
 pub struct Window {
     ns_window: id,
@@ -19,9 +19,9 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn open<A: AppWindow>(
+    pub fn open<H: WindowHandler>(
         options: WindowOpenOptions,
-        app_message_rx: mpsc::Receiver<A::AppMessage>,
+        app_message_rx: mpsc::Receiver<H::Message>,
     ) {
         unsafe {
             let _pool = NSAutoreleasePool::new(nil);
@@ -49,12 +49,9 @@ impl Window {
             let ns_view = NSView::alloc(nil).init();
             ns_window.setContentView_(ns_view);
 
-            let mut window = Window {
-                ns_window,
-                ns_view,
-            };
+            let mut window = Window { ns_window, ns_view };
 
-            let app_window = A::build(&mut window);
+            let handler = H::build(&mut window);
 
             let current_app = NSRunningApplication::currentApplication(nil);
             current_app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps);

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -1,5 +1,4 @@
 use std::ffi::c_void;
-use std::sync::mpsc;
 
 use cocoa::appkit::{
     NSApp, NSApplication, NSApplicationActivateIgnoringOtherApps,
@@ -19,10 +18,7 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn open<H: WindowHandler>(
-        options: WindowOpenOptions,
-        app_message_rx: mpsc::Receiver<H::Message>,
-    ) {
+    pub fn open<H: WindowHandler>(options: WindowOpenOptions) {
         unsafe {
             let _pool = NSAutoreleasePool::new(nil);
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -18,7 +18,7 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn open<H: WindowHandler>(options: WindowOpenOptions) {
+    pub fn open<H: WindowHandler>(options: WindowOpenOptions) -> WindowHandle {
         unsafe {
             let _pool = NSAutoreleasePool::new(nil);
 
@@ -52,6 +52,8 @@ impl Window {
             let current_app = NSRunningApplication::currentApplication(nil);
             current_app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps);
             app.run();
+
+            WindowHandle
         }
     }
 }
@@ -65,3 +67,5 @@ unsafe impl HasRawWindowHandle for Window {
         })
     }
 }
+
+pub struct WindowHandle;

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -15,7 +15,6 @@ use std::cell::RefCell;
 use std::ffi::c_void;
 use std::ptr::null_mut;
 use std::rc::Rc;
-use std::sync::mpsc;
 
 use raw_window_handle::{windows::WindowsHandle, HasRawWindowHandle, RawWindowHandle};
 
@@ -137,10 +136,7 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn open<H: WindowHandler>(
-        options: WindowOpenOptions,
-        app_message_rx: mpsc::Receiver<H::Message>,
-    ) {
+    pub fn open<H: WindowHandler>(options: WindowOpenOptions) {
         unsafe {
             let title = (options.title.to_owned() + "\0").as_ptr() as *const i8;
 

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -136,7 +136,7 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn open<H: WindowHandler>(options: WindowOpenOptions) {
+    pub fn open<H: WindowHandler>(options: WindowOpenOptions) -> WindowHandle {
         unsafe {
             let title = (options.title.to_owned() + "\0").as_ptr() as *const i8;
 
@@ -213,6 +213,8 @@ impl Window {
                 }
             }
         }
+
+        WindowHandle
     }
 }
 
@@ -224,3 +226,5 @@ unsafe impl HasRawWindowHandle for Window {
         })
     }
 }
+
+pub struct WindowHandle;

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -6,18 +6,20 @@ use winapi::um::winuser::{
     AdjustWindowRectEx, CreateWindowExA, DefWindowProcA, DestroyWindow, DispatchMessageA,
     GetMessageA, GetWindowLongPtrA, MessageBoxA, PostMessageA, RegisterClassA, SetTimer,
     SetWindowLongPtrA, TranslateMessage, UnregisterClassA, CS_OWNDC, GWLP_USERDATA, MB_ICONERROR,
-    MB_OK, MB_TOPMOST, MSG, WM_CREATE, WM_MOUSEMOVE, WM_PAINT, WM_SHOWWINDOW, WM_TIMER, WNDCLASSA,
-    WS_CAPTION, WS_CHILD, WS_CLIPSIBLINGS, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUPWINDOW,
-    WS_SIZEBOX, WS_VISIBLE,
+    MB_OK, MB_TOPMOST, MSG, WM_CLOSE, WM_CREATE, WM_MOUSEMOVE, WM_PAINT, WM_SHOWWINDOW, WM_TIMER,
+    WNDCLASSA, WS_CAPTION, WS_CHILD, WS_CLIPSIBLINGS, WS_MAXIMIZEBOX, WS_MINIMIZEBOX,
+    WS_POPUPWINDOW, WS_SIZEBOX, WS_VISIBLE,
 };
 
+use std::cell::RefCell;
 use std::ffi::c_void;
 use std::ptr::null_mut;
-use std::sync::mpsc;
 use std::rc::Rc;
-use std::cell::RefCell;
+use std::sync::mpsc;
 
-use crate::{AppWindow, Event, Parent::WithParent, RawWindow, WindowInfo, WindowOpenOptions};
+use raw_window_handle::{windows::WindowsHandle, HasRawWindowHandle, RawWindowHandle};
+
+use crate::{AppWindow, Event, Parent::WithParent, WindowInfo, WindowOpenOptions};
 
 unsafe fn message_box(title: &str, msg: &str) {
     let title = (title.to_owned() + "\0").as_ptr() as *const i8;
@@ -46,7 +48,7 @@ unsafe fn generate_guid() -> String {
 
 const WIN_FRAME_TIMER: usize = 4242;
 
-unsafe fn handle_timer<A: AppWindow>(win: &RefCell<Window<A>>, timer_id: usize) {
+unsafe fn handle_timer<A: AppWindow>(window_state: &RefCell<WindowState<A>>, timer_id: usize) {
     match timer_id {
         WIN_FRAME_TIMER => {}
         _ => (),
@@ -66,21 +68,32 @@ unsafe extern "system" fn wnd_proc<A: AppWindow>(
 
     let win_ptr = GetWindowLongPtrA(hwnd, GWLP_USERDATA) as *const c_void;
     if !win_ptr.is_null() {
-        let win = &*(win_ptr as *const RefCell<Window<A>>);
+        let window_state = &*(win_ptr as *const RefCell<WindowState<A>>);
+        let mut window = Window { hwnd };
 
         match msg {
             WM_MOUSEMOVE => {
                 let x = (lparam & 0xFFFF) as i32;
                 let y = ((lparam >> 16) & 0xFFFF) as i32;
-                win.borrow_mut().handle_mouse_motion(x, y);
+                window_state
+                    .borrow_mut()
+                    .app_window
+                    .on_event(&mut window, Event::CursorMotion(x, y));
                 return 0;
             }
             WM_TIMER => {
-                handle_timer(&win, wparam);
+                handle_timer(&window_state, wparam);
                 return 0;
             }
             WM_PAINT => {
                 return 0;
+            }
+            WM_CLOSE => {
+                window_state
+                    .borrow_mut()
+                    .app_window
+                    .on_event(&mut window, Event::WillClose);
+                return DefWindowProcA(hwnd, msg, wparam, lparam);
             }
             _ => {}
         }
@@ -113,16 +126,21 @@ unsafe fn unregister_wnd_class(wnd_class: ATOM) {
     UnregisterClassA(wnd_class as _, null_mut());
 }
 
-pub struct Window<A: AppWindow> {
-    pub(crate) hwnd: HWND,
+struct WindowState<A> {
     window_class: ATOM,
-    app_window: A,
-    app_message_rx: mpsc::Receiver<A::AppMessage>,
     scaling: Option<f64>, // DPI scale, 96.0 is "default".
+    app_window: A,
 }
 
-impl<A: AppWindow> Window<A> {
-    pub fn open(options: WindowOpenOptions, app_message_rx: mpsc::Receiver<A::AppMessage>) {
+pub struct Window {
+    hwnd: HWND,
+}
+
+impl Window {
+    pub fn open<A: AppWindow>(
+        options: WindowOpenOptions,
+        app_message_rx: mpsc::Receiver<A::AppMessage>,
+    ) {
         unsafe {
             let title = (options.title.to_owned() + "\0").as_ptr() as *const i8;
 
@@ -170,28 +188,15 @@ impl<A: AppWindow> Window<A> {
             );
             // todo: manage error ^
 
-            let mut windows_handle = raw_window_handle::windows::WindowsHandle::empty();
-            windows_handle.hwnd = hwnd as *mut std::ffi::c_void;
+            let mut window = Window { hwnd };
 
-            let raw_window = RawWindow {
-                raw_window_handle: raw_window_handle::RawWindowHandle::Windows(windows_handle),
-            };
+            let app_window = A::build(&mut window);
 
-            let window_info = WindowInfo {
-                width: options.width as u32,
-                height: options.height as u32,
-                scale: 1.0,
-            };
-
-            let app_window = A::build(raw_window, &window_info);
-
-            let window = Window {
-                hwnd,
+            let window_state = Rc::new(RefCell::new(WindowState {
                 window_class,
-                app_window,
-                app_message_rx,
                 scaling: None,
-            };
+                app_window,
+            }));
 
             let win = Rc::new(RefCell::new(window));
 
@@ -213,18 +218,13 @@ impl<A: AppWindow> Window<A> {
             }
         }
     }
+}
 
-    pub fn close(&mut self) {
-        self.app_window.on_event(Event::WillClose);
-
-        // todo: see https://github.com/wrl/rutabaga/blob/f30ff67e157375cafdbafe5fb549f1790443a3a8/src/platform/win/window.c#L402
-        unsafe {
-            DestroyWindow(self.hwnd);
-            unregister_wnd_class(self.window_class);
-        }
-    }
-
-    pub(crate) fn handle_mouse_motion(&mut self, x: i32, y: i32) {
-        self.app_window.on_event(Event::CursorMotion(x, y));
+unsafe impl HasRawWindowHandle for Window {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        RawWindowHandle::Windows(WindowsHandle {
+            hwnd: self.hwnd as *mut std::ffi::c_void,
+            ..WindowsHandle::empty()
+        })
     }
 }

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -1,6 +1,5 @@
 use std::ffi::CStr;
 use std::os::raw::{c_ulong, c_void};
-use std::sync::mpsc;
 
 use super::XcbConnection;
 use crate::{Event, MouseButtonID, MouseScroll, Parent, WindowHandler, WindowOpenOptions};
@@ -14,10 +13,7 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn open<H: WindowHandler>(
-        options: WindowOpenOptions,
-        app_message_rx: mpsc::Receiver<H::Message>,
-    ) {
+    pub fn open<H: WindowHandler>(options: WindowOpenOptions) {
         // Convert the parent to a X11 window ID if we're given one
         let parent = match options.parent {
             Parent::None => None,
@@ -122,8 +118,6 @@ unsafe impl HasRawWindowHandle for Window {
 // Event loop
 fn run_event_loop<H: WindowHandler>(window: &mut Window, handler: &mut H) {
     loop {
-        // somehow poll app_message_rx for messages at the same time
-
         let ev = window.xcb_connection.conn.wait_for_event();
         if let Some(event) = ev {
             let event_type = event.response_type() & !0x80;

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -13,7 +13,7 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn open<H: WindowHandler>(options: WindowOpenOptions) {
+    pub fn open<H: WindowHandler>(options: WindowOpenOptions) -> WindowHandle {
         // Convert the parent to a X11 window ID if we're given one
         let parent = match options.parent {
             Parent::None => None,
@@ -102,6 +102,8 @@ impl Window {
         let mut handler = H::build(&mut window);
 
         run_event_loop(&mut window, &mut handler);
+
+        WindowHandle
     }
 }
 
@@ -114,6 +116,8 @@ unsafe impl HasRawWindowHandle for Window {
         })
     }
 }
+
+pub struct WindowHandle;
 
 // Event loop
 fn run_event_loop<H: WindowHandler>(window: &mut Window, handler: &mut H) {

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -4,20 +4,19 @@ use std::sync::mpsc;
 
 use super::XcbConnection;
 use crate::{
-    AppWindow, Event, MouseButtonID, MouseScroll, Parent, RawWindow, WindowInfo, WindowOpenOptions,
+    AppWindow, Event, MouseButtonID, MouseScroll, Parent, WindowOpenOptions,
 };
 
-use raw_window_handle::RawWindowHandle;
+use raw_window_handle::{unix::XlibHandle, HasRawWindowHandle, RawWindowHandle};
 
-pub struct Window<A: AppWindow> {
-    scaling: f64,
+pub struct Window {
     xcb_connection: XcbConnection,
-    app_window: A,
-    app_message_rx: mpsc::Receiver<A::AppMessage>,
+    window_id: u32,
+    scaling: f64,
 }
 
-impl<A: AppWindow> Window<A> {
-    pub fn open(options: WindowOpenOptions, app_message_rx: mpsc::Receiver<A::AppMessage>) -> Self {
+impl Window {
+    pub fn open<A: AppWindow>(options: WindowOpenOptions, app_message_rx: mpsc::Receiver<A::AppMessage>) {
         // Convert the parent to a X11 window ID if we're given one
         let parent = match options.parent {
             Parent::None => None,
@@ -93,131 +92,122 @@ impl<A: AppWindow> Window<A> {
 
         xcb_connection.conn.flush();
 
-        let raw_handle = RawWindowHandle::Xlib(raw_window_handle::unix::XlibHandle {
-            window: window_id as c_ulong,
-            display: xcb_connection.conn.get_raw_dpy() as *mut c_void,
-            ..raw_window_handle::unix::XlibHandle::empty()
-        });
-
-        let raw_window = RawWindow {
-            raw_window_handle: raw_handle,
-        };
-
         let scaling = get_scaling_xft(&xcb_connection)
             .or(get_scaling_screen_dimensions(&xcb_connection))
             .unwrap_or(1.0);
 
-        let window_info = WindowInfo {
-            width: options.width as u32,
-            height: options.height as u32,
-            scale: scaling,
-        };
-
-        let app_window = A::build(raw_window, &window_info);
-
-        let mut x11_window = Self {
-            scaling,
+        let mut window = Self {
             xcb_connection,
-            app_window,
-            app_message_rx,
+            window_id,
+            scaling,
         };
 
-        x11_window.run_event_loop();
+        let mut app_window = A::build(&mut window);
 
-        x11_window
+        run_event_loop(&mut window, &mut app_window);
     }
+}
 
-    // Event loop
-    fn run_event_loop(&mut self) {
-        loop {
-            // somehow poll self.app_message_rx for messages at the same time
+unsafe impl HasRawWindowHandle for Window {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        RawWindowHandle::Xlib(XlibHandle {
+            window: self.window_id as c_ulong,
+            display: self.xcb_connection.conn.get_raw_dpy() as *mut c_void,
+            ..raw_window_handle::unix::XlibHandle::empty()
+        })
+    }
+}
 
-            let ev = self.xcb_connection.conn.wait_for_event();
-            if let Some(event) = ev {
-                let event_type = event.response_type() & !0x80;
+// Event loop
+fn run_event_loop<A: AppWindow>(window: &mut Window, app_window: &mut A) {
+    loop {
+        // somehow poll app_message_rx for messages at the same time
 
-                // For all of the keyboard and mouse events, you can fetch
-                // `x`, `y`, `detail`, and `state`.
-                // - `x` and `y` are the position inside the window where the cursor currently is
-                //   when the event happened.
-                // - `detail` will tell you which keycode was pressed/released (for keyboard events)
-                //   or which mouse button was pressed/released (for mouse events).
-                //   For mouse events, here's what the value means (at least on my current mouse):
-                //      1 = left mouse button
-                //      2 = middle mouse button (scroll wheel)
-                //      3 = right mouse button
-                //      4 = scroll wheel up
-                //      5 = scroll wheel down
-                //      8 = lower side button ("back" button)
-                //      9 = upper side button ("forward" button)
-                //   Note that you *will* get a "button released" event for even the scroll wheel
-                //   events, which you can probably ignore.
-                // - `state` will tell you the state of the main three mouse buttons and some of
-                //   the keyboard modifier keys at the time of the event.
-                //   http://rtbo.github.io/rust-xcb/src/xcb/ffi/xproto.rs.html#445
+        let ev = window.xcb_connection.conn.wait_for_event();
+        if let Some(event) = ev {
+            let event_type = event.response_type() & !0x80;
 
-                match event_type {
-                    xcb::EXPOSE => {
-                        self.app_window.draw();
+            // For all of the keyboard and mouse events, you can fetch
+            // `x`, `y`, `detail`, and `state`.
+            // - `x` and `y` are the position inside the window where the cursor currently is
+            //   when the event happened.
+            // - `detail` will tell you which keycode was pressed/released (for keyboard events)
+            //   or which mouse button was pressed/released (for mouse events).
+            //   For mouse events, here's what the value means (at least on my current mouse):
+            //      1 = left mouse button
+            //      2 = middle mouse button (scroll wheel)
+            //      3 = right mouse button
+            //      4 = scroll wheel up
+            //      5 = scroll wheel down
+            //      8 = lower side button ("back" button)
+            //      9 = upper side button ("forward" button)
+            //   Note that you *will* get a "button released" event for even the scroll wheel
+            //   events, which you can probably ignore.
+            // - `state` will tell you the state of the main three mouse buttons and some of
+            //   the keyboard modifier keys at the time of the event.
+            //   http://rtbo.github.io/rust-xcb/src/xcb/ffi/xproto.rs.html#445
+
+            match event_type {
+                xcb::EXPOSE => {
+                    app_window.draw(window);
+                }
+                xcb::MOTION_NOTIFY => {
+                    let event = unsafe { xcb::cast_event::<xcb::MotionNotifyEvent>(&event) };
+                    let detail = event.detail();
+
+                    if detail != 4 && detail != 5 {
+                        app_window.on_event(window, Event::CursorMotion(
+                            event.event_x() as i32,
+                            event.event_y() as i32,
+                        ));
                     }
-                    xcb::MOTION_NOTIFY => {
-                        let event = unsafe { xcb::cast_event::<xcb::MotionNotifyEvent>(&event) };
-                        let detail = event.detail();
+                }
+                xcb::BUTTON_PRESS => {
+                    let event = unsafe { xcb::cast_event::<xcb::ButtonPressEvent>(&event) };
+                    let detail = event.detail();
 
-                        if detail != 4 && detail != 5 {
-                            self.app_window.on_event(Event::CursorMotion(
-                                event.event_x() as i32,
-                                event.event_y() as i32,
-                            ));
+                    match detail {
+                        4 => {
+                            app_window.on_event(window, Event::MouseScroll(MouseScroll {
+                                x_delta: 0.0,
+                                y_delta: 1.0,
+                            }));
                         }
-                    }
-                    xcb::BUTTON_PRESS => {
-                        let event = unsafe { xcb::cast_event::<xcb::ButtonPressEvent>(&event) };
-                        let detail = event.detail();
-
-                        match detail {
-                            4 => {
-                                self.app_window.on_event(Event::MouseScroll(MouseScroll {
-                                    x_delta: 0.0,
-                                    y_delta: 1.0,
-                                }));
-                            }
-                            5 => {
-                                self.app_window.on_event(Event::MouseScroll(MouseScroll {
-                                    x_delta: 0.0,
-                                    y_delta: -1.0,
-                                }));
-                            }
-                            detail => {
-                                let button_id = mouse_id(detail);
-                                self.app_window.on_event(Event::MouseDown(button_id));
-                            }
+                        5 => {
+                            app_window.on_event(window, Event::MouseScroll(MouseScroll {
+                                x_delta: 0.0,
+                                y_delta: -1.0,
+                            }));
                         }
-                    }
-                    xcb::BUTTON_RELEASE => {
-                        let event = unsafe { xcb::cast_event::<xcb::ButtonPressEvent>(&event) };
-                        let detail = event.detail();
-
-                        if detail != 4 && detail != 5 {
+                        detail => {
                             let button_id = mouse_id(detail);
-                            self.app_window.on_event(Event::MouseUp(button_id));
+                            app_window.on_event(window, Event::MouseDown(button_id));
                         }
                     }
-                    xcb::KEY_PRESS => {
-                        let event = unsafe { xcb::cast_event::<xcb::KeyPressEvent>(&event) };
-                        let detail = event.detail();
+                }
+                xcb::BUTTON_RELEASE => {
+                    let event = unsafe { xcb::cast_event::<xcb::ButtonPressEvent>(&event) };
+                    let detail = event.detail();
 
-                        self.app_window.on_event(Event::KeyDown(detail));
+                    if detail != 4 && detail != 5 {
+                        let button_id = mouse_id(detail);
+                        app_window.on_event(window, Event::MouseUp(button_id));
                     }
-                    xcb::KEY_RELEASE => {
-                        let event = unsafe { xcb::cast_event::<xcb::KeyReleaseEvent>(&event) };
-                        let detail = event.detail();
+                }
+                xcb::KEY_PRESS => {
+                    let event = unsafe { xcb::cast_event::<xcb::KeyPressEvent>(&event) };
+                    let detail = event.detail();
 
-                        self.app_window.on_event(Event::KeyUp(detail));
-                    }
-                    _ => {
-                        println!("Unhandled event type: {:?}", event_type);
-                    }
+                    app_window.on_event(window, Event::KeyDown(detail));
+                }
+                xcb::KEY_RELEASE => {
+                    let event = unsafe { xcb::cast_event::<xcb::KeyReleaseEvent>(&event) };
+                    let detail = event.detail();
+
+                    app_window.on_event(window, Event::KeyUp(detail));
+                }
+                _ => {
+                    println!("Unhandled event type: {:?}", event_type);
                 }
             }
         }


### PR DESCRIPTION
Various API changes:

- Rename AppWindow to WindowHandler
- Pass an &mut Window to WindowHandler trait methods
- Implement HasRawWindowHandle for Window
- Remove mpsc channel and replace with a WindowHandle struct