### PR TITLE
Add frame_interval_secs to WindowOpenOptions

### DIFF
--- a/examples/open_window.rs
+++ b/examples/open_window.rs
@@ -28,6 +28,7 @@ fn main() {
         width: 512,
         height: 512,
         parent: baseview::Parent::None,
+        ..Default::default()
     };
 
     let handle = Window::open::<MyProgram>(window_open_options);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,10 +33,24 @@ unsafe impl Send for Parent {}
 pub struct WindowOpenOptions {
     pub title: String,
 
-    pub width: usize,
-    pub height: usize,
+    pub width: u32,
+    pub height: u32,
 
     pub parent: Parent,
+
+    pub frame_interval_secs: f64,
+}
+
+impl Default for WindowOpenOptions {
+    fn default() -> Self {
+        Self {
+            title: String::from("baseview"),
+            width: 640,
+            height: 480,
+            parent: Parent::None,
+            frame_interval_secs: 15.0 / 1000.0,
+        }
+    }
 }
 
 pub trait WindowHandler {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ impl Default for WindowOpenOptions {
             width: 640,
             height: 480,
             parent: Parent::None,
-            frame_interval_secs: 15.0 / 1000.0,
+            frame_interval_secs: 1.0 / 60.0,
         }
     }
 }

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -158,7 +158,7 @@ impl Window {
             window_info,
             mouse_cursor: MouseCursor::default(),
 
-            frame_interval: Duration::from_millis(15),
+            frame_interval: Duration::from_secs_f64(options.frame_interval_secs),
             event_loop_running: false,
 
             new_size: None


### PR DESCRIPTION
To achieve lower input latency in `iced`, I need the frame interval to run at 120fps. Iced sets the `wgpu` swapchain to `Mailbox` mode, so rendering still happens at 60fps. However, this causes less misses for the current frame reducing the perceived latency.