### PR TITLE
replace `WindowHandler::build()` with closure passed to `Window::open()`

### DIFF
--- a/examples/open_window.rs
+++ b/examples/open_window.rs
@@ -1,13 +1,9 @@
 use baseview::{Event, Window, WindowHandler};
 
-struct MyProgram {}
+struct OpenWindowExample;
 
-impl WindowHandler for MyProgram {
+impl WindowHandler for OpenWindowExample {
     type Message = ();
-
-    fn build(_window: &mut Window) -> Self {
-        Self {}
-    }
 
     fn on_frame(&mut self) {}
 
@@ -30,6 +26,6 @@ fn main() {
         parent: baseview::Parent::None,
     };
 
-    let handle = Window::open::<MyProgram>(window_open_options);
+    let handle = Window::open(window_open_options, |_| OpenWindowExample);
     handle.app_run_blocking();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,6 @@ pub struct WindowOpenOptions {
 pub trait WindowHandler {
     type Message;
 
-    fn build(window: &mut Window) -> Self;
-
     fn on_frame(&mut self);
     fn on_event(&mut self, window: &mut Window, event: Event);
     fn on_message(&mut self, window: &mut Window, message: Self::Message);

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -33,7 +33,11 @@ impl WindowHandle {
 }
 
 impl Window {
-    pub fn open<H: WindowHandler>(options: WindowOpenOptions) -> WindowHandle {
+    pub fn open<H, B>(options: WindowOpenOptions, build: B) -> WindowHandle
+        where H: WindowHandler,
+              B: FnOnce(&mut Window) -> H,
+              B: Send + 'static
+    {
         unsafe {
             let _pool = NSAutoreleasePool::new(nil);
 
@@ -59,7 +63,7 @@ impl Window {
 
             let mut window = Window { ns_window, ns_view };
 
-            let handler = H::build(&mut window);
+            let handler = build(&mut window);
 
             // FIXME: only do this in the unparented case
             let current_app = NSRunningApplication::currentApplication(nil);

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -166,7 +166,11 @@ impl WindowHandle {
 }
 
 impl Window {
-    pub fn open<H: WindowHandler>(options: WindowOpenOptions) -> WindowHandle {
+    pub fn open<H, B>(options: WindowOpenOptions, build: B) -> WindowHandle
+        where H: WindowHandler,
+              B: FnOnce(&mut Window) -> H,
+              B: Send + 'static
+    {
         unsafe {
             let title = (options.title.to_owned() + "\0").as_ptr() as *const i8;
 
@@ -222,7 +226,7 @@ impl Window {
 
             let mut window = Window { hwnd };
 
-            let handler = H::build(&mut window);
+            let handler = build(&mut window);
 
             let window_state = Rc::new(RefCell::new(WindowState {
                 window_class,


### PR DESCRIPTION
This PR makes it substantially easier to construct a window which incorporates state from outside the window context.