### PR TITLE
macOS: basic event handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,6 @@ winapi = { version = "0.3.8", features = ["libloaderapi", "winuser", "windef", "
 
 [target.'cfg(target_os="macos")'.dependencies]
 cocoa = "0.23.0"
+fastrand = "1"
 objc = "0.2.7"
+once_cell = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,4 @@ winapi = { version = "0.3.8", features = ["libloaderapi", "winuser", "windef", "
 [target.'cfg(target_os="macos")'.dependencies]
 cocoa = "0.23.0"
 objc = "0.2.7"
-once_cell = "1"
 uuid = { version = "0.8", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ winapi = { version = "0.3.8", features = ["libloaderapi", "winuser", "windef", "
 
 [target.'cfg(target_os="macos")'.dependencies]
 cocoa = "0.23.0"
-fastrand = "1"
 objc = "0.2.7"
 once_cell = "1"
+uuid = { version = "0.8", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ authors = [
     "Mirko Covizzi <mrkcvzz@gmail.com>",
     "Micah Johnston <micah@glowcoil.com>",
     "Billy Messenger <billydm@protonmail.com>",
+    "Anton Lazarev <https://antonok.com>",
+    "Joakim Frostegård <joakim.frostegard@gmail.com>",
 ]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,6 @@ nix = "0.18"
 winapi = { version = "0.3.8", features = ["libloaderapi", "winuser", "windef", "minwindef", "guiddef", "combaseapi", "wingdi", "errhandlingapi"] }
 
 [target.'cfg(target_os="macos")'.dependencies]
-cocoa = "0.23.0"
+cocoa = "0.24.0"
 objc = "0.2.7"
 uuid = { version = "0.8", features = ["v4"] }

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,2 +1,4 @@
 mod window;
+mod subview;
+
 pub use window::*;

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,4 +1,4 @@
 mod window;
-mod subview;
+mod view;
 
 pub use window::*;

--- a/src/macos/subview.rs
+++ b/src/macos/subview.rs
@@ -1,0 +1,123 @@
+use std::ffi::c_void;
+use std::sync::Arc;
+
+use cocoa::appkit::{NSEvent, NSView};
+use cocoa::base::id;
+use cocoa::foundation::{NSPoint, NSRect, NSSize};
+
+use objc::{
+    class,
+    declare::ClassDecl,
+    msg_send,
+    runtime::{Object, Sel},
+    sel, sel_impl,
+};
+
+use crate::{Event, MouseButton, WindowHandler, WindowOpenOptions};
+use crate::MouseEvent::{ButtonPressed, ButtonReleased};
+
+use super::window::{WindowState, WINDOW_STATE_IVAR_NAME};
+
+
+pub(super) unsafe fn create_subview<H: WindowHandler>(
+    window_options: &WindowOpenOptions,
+) -> id {
+    let mut class = ClassDecl::new("BaseviewNSView", class!(NSView))
+        .unwrap();
+
+    class.add_method(
+        sel!(dealloc),
+        dealloc::<H> as extern "C" fn(&Object, Sel)
+    );
+
+    class.add_method(
+        sel!(mouseMoved:),
+        mouse_moved::<H> as extern "C" fn(&Object, Sel, id),
+    );
+    class.add_method(
+        sel!(mouseDragged:),
+        mouse_moved::<H> as extern "C" fn(&Object, Sel, id),
+    );
+
+    class.add_method(
+        sel!(mouseDown:),
+        left_mouse_down::<H> as extern "C" fn(&Object, Sel, id),
+    );
+    class.add_method(
+        sel!(mouseUp:),
+        left_mouse_up::<H> as extern "C" fn(&Object, Sel, id),
+    );
+
+    class.add_method(
+        sel!(rightMouseDown:),
+        right_mouse_down::<H> as extern "C" fn(&Object, Sel, id),
+    );
+    class.add_method(
+        sel!(rightMouseUp:),
+        right_mouse_up::<H> as extern "C" fn(&Object, Sel, id),
+    );
+
+    class.add_method(
+        sel!(otherMouseDown:),
+        middle_mouse_down::<H> as extern "C" fn(&Object, Sel, id),
+    );
+    class.add_method(
+        sel!(otherMouseUp:),
+        middle_mouse_up::<H> as extern "C" fn(&Object, Sel, id),
+    );
+
+    class.add_ivar::<*mut c_void>(WINDOW_STATE_IVAR_NAME);
+
+    let class = class.register();
+    let subview: id = msg_send![class, alloc];
+
+    let size = window_options.size;
+
+    subview.initWithFrame_(NSRect::new(
+        NSPoint::new(0., 0.),
+        NSSize::new(size.width, size.height),
+    ));
+
+    subview
+}
+
+
+extern "C" fn dealloc<H: WindowHandler>(this: &Object, _sel: Sel) {
+    unsafe {
+        let state_ptr: *mut c_void = *this.get_ivar(WINDOW_STATE_IVAR_NAME);
+        Arc::from_raw(state_ptr as *mut WindowState<H>);
+    }
+}
+
+
+extern "C" fn mouse_moved<H: WindowHandler>(this: &Object, _sel: Sel, event: id) {
+    let location = unsafe { NSEvent::locationInWindow(event) };
+    let state: &mut WindowState<H> = WindowState::from_field(this);
+
+    state.trigger_cursor_moved(location);
+}
+
+
+macro_rules! mouse_click_extern_fn {
+    ($fn:ident, $event:expr) => {
+        extern "C" fn $fn<H: WindowHandler>(this: &Object, _sel: Sel, event: id) {
+            let location = unsafe { NSEvent::locationInWindow(event) };
+            let state: &mut WindowState<H> = WindowState::from_field(this);
+
+            state.trigger_cursor_moved(location);
+
+            let event = Event::Mouse($event);
+            state.window_handler.on_event(&mut state.window, event);
+        }
+    };
+}
+
+
+mouse_click_extern_fn!(left_mouse_down, ButtonPressed(MouseButton::Left));
+mouse_click_extern_fn!(left_mouse_up, ButtonReleased(MouseButton::Left));
+
+mouse_click_extern_fn!(right_mouse_down, ButtonPressed(MouseButton::Right));
+mouse_click_extern_fn!(right_mouse_up, ButtonReleased(MouseButton::Right));
+
+mouse_click_extern_fn!(middle_mouse_down, ButtonPressed(MouseButton::Middle));
+mouse_click_extern_fn!(middle_mouse_up, ButtonReleased(MouseButton::Middle));

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -13,6 +13,7 @@ use objc::{
     sel, sel_impl,
 };
 use once_cell::sync::OnceCell;
+use uuid::Uuid;
 
 use crate::{
     Event, MouseButton, MouseEvent, Point, WindowHandler,
@@ -49,21 +50,10 @@ pub(super) unsafe fn create_view<H: WindowHandler>(
 
 
 unsafe fn create_view_class<H: WindowHandler>() -> &'static Class {
-    let mut class = None;
-
     // Use unique class names to make sure that differing class definitions in
     // plugins compiled with different versions of baseview don't cause issues.
-    for _ in 0..10 {
-        let class_name = format!("BaseviewNSView_{}", ::fastrand::usize(0..));
-
-        class = ClassDecl::new(&class_name, class!(NSView));
-
-        if class.is_some(){
-            break
-        }
-    }
-
-    let mut class = class.unwrap();
+    let class_name = format!("BaseviewNSView_{}", Uuid::new_v4().to_simple());
+    let mut class = ClassDecl::new(&class_name, class!(NSView)).unwrap();
 
     class.add_method(
         sel!(acceptsFirstResponder),

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -153,11 +153,8 @@ extern "C" fn mouse_moved<H: WindowHandler>(this: &Object, _sel: Sel, event: id)
 
 macro_rules! mouse_button_extern_fn {
     ($fn:ident, $event:expr) => {
-        extern "C" fn $fn<H: WindowHandler>(this: &Object, _sel: Sel, event: id) {
-            let location = unsafe { NSEvent::locationInWindow(event) };
+        extern "C" fn $fn<H: WindowHandler>(this: &Object, _sel: Sel, _event: id) {
             let state: &mut WindowState<H> = WindowState::from_field(this);
-
-            state.trigger_cursor_moved(location);
 
             let event = Event::Mouse($event);
             state.window_handler.on_event(&mut state.window, event);

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -66,6 +66,14 @@ pub(super) unsafe fn create_view<H: WindowHandler>(
         sel!(mouseDragged:),
         mouse_moved::<H> as extern "C" fn(&Object, Sel, id),
     );
+    class.add_method(
+        sel!(rightMouseDragged:),
+        mouse_moved::<H> as extern "C" fn(&Object, Sel, id),
+    );
+    class.add_method(
+        sel!(otherMouseDragged:),
+        mouse_moved::<H> as extern "C" fn(&Object, Sel, id),
+    );
 
     class.add_method(
         sel!(mouseEntered:),

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -2,7 +2,7 @@ use std::ffi::c_void;
 use std::sync::Arc;
 
 use cocoa::appkit::{NSEvent, NSView};
-use cocoa::base::{id, nil, BOOL, YES};
+use cocoa::base::{id, nil, BOOL, YES, NO};
 use cocoa::foundation::{NSArray, NSPoint, NSRect, NSSize};
 
 use objc::{
@@ -196,6 +196,8 @@ extern "C" fn view_will_move_to_window<H: WindowHandler>(this: &Object, _self: S
     unsafe {
         let tracking_areas: *mut Object = msg_send![this, trackingAreas];
         let tracking_area_count = NSArray::count(tracking_areas);
+
+        let _: () = msg_send![class!(NSEvent), setMouseCoalescingEnabled:NO];
 
         if new_window == nil {
             if tracking_area_count != 0 {

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -192,7 +192,11 @@ unsafe fn reinit_tracking_area(this: &Object, tracking_area: *mut Object){
 }
 
 
-extern "C" fn view_will_move_to_window<H: WindowHandler>(this: &Object, _self: Sel, new_window: id){
+extern "C" fn view_will_move_to_window<H: WindowHandler>(
+    this: &Object,
+    _self: Sel,
+    new_window: id
+){
     unsafe {
         let tracking_areas: *mut Object = msg_send![this, trackingAreas];
         let tracking_area_count = NSArray::count(tracking_areas);
@@ -232,7 +236,11 @@ extern "C" fn view_will_move_to_window<H: WindowHandler>(this: &Object, _self: S
 }
 
 
-extern "C" fn update_tracking_areas<H: WindowHandler>(this: &Object, _self: Sel, _: id){
+extern "C" fn update_tracking_areas<H: WindowHandler>(
+    this: &Object,
+    _self: Sel,
+    _: id
+){
     unsafe {
         let tracking_areas: *mut Object = msg_send![this, trackingAreas];
         let tracking_area = NSArray::objectAtIndex(tracking_areas, 0);
@@ -242,7 +250,11 @@ extern "C" fn update_tracking_areas<H: WindowHandler>(this: &Object, _self: Sel,
 }
 
 
-extern "C" fn mouse_moved<H: WindowHandler>(this: &Object, _sel: Sel, event: id) {
+extern "C" fn mouse_moved<H: WindowHandler>(
+    this: &Object,
+    _sel: Sel,
+    event: id
+){
     let state: &mut WindowState<H> = WindowState::from_field(this);
 
     let point: NSPoint = unsafe {
@@ -264,7 +276,11 @@ extern "C" fn mouse_moved<H: WindowHandler>(this: &Object, _sel: Sel, event: id)
 
 macro_rules! mouse_simple_extern_fn {
     ($fn:ident, $event:expr) => {
-        extern "C" fn $fn<H: WindowHandler>(this: &Object, _sel: Sel, _event: id) {
+        extern "C" fn $fn<H: WindowHandler>(
+            this: &Object,
+            _sel: Sel,
+            _event: id,
+        ){
             let state: &mut WindowState<H> = WindowState::from_field(this);
 
             state.trigger_event(Event::Mouse($event));

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -246,9 +246,9 @@ extern "C" fn view_will_move_to_window<H: WindowHandler>(
     }
 
     unsafe {
-        let superview: &Object = msg_send![this, superview];
+        let superclass = msg_send![this, superclass];
 
-        let _: () = msg_send![superview, viewWillMoveToWindow:new_window];
+        let () = msg_send![super(this, superclass), viewWillMoveToWindow:new_window];
     }
 }
 

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -29,16 +29,21 @@ pub(super) unsafe fn create_view<H: WindowHandler>(
         .unwrap();
 
     class.add_method(
-        sel!(dealloc),
-        dealloc::<H> as extern "C" fn(&Object, Sel)
-    );
-    class.add_method(
         sel!(acceptsFirstResponder),
-        accepts_first_responder::<H> as extern "C" fn(&Object, Sel) -> BOOL
+        property_yes::<H> as extern "C" fn(&Object, Sel) -> BOOL
     );
     class.add_method(
         sel!(isFlipped),
-        is_flipped::<H> as extern "C" fn(&Object, Sel) -> BOOL
+        property_yes::<H> as extern "C" fn(&Object, Sel) -> BOOL
+    );
+    class.add_method(
+        sel!(preservesContentInLiveResize),
+        property_no::<H> as extern "C" fn(&Object, Sel) -> BOOL
+    );
+
+    class.add_method(
+        sel!(dealloc),
+        dealloc::<H> as extern "C" fn(&Object, Sel)
     );
 
     class.add_method(
@@ -110,7 +115,7 @@ extern "C" fn dealloc<H: WindowHandler>(this: &Object, _sel: Sel) {
 }
 
 
-extern "C" fn accepts_first_responder<H: WindowHandler>(
+extern "C" fn property_yes<H: WindowHandler>(
     _this: &Object,
     _sel: Sel,
 ) -> BOOL {
@@ -118,7 +123,7 @@ extern "C" fn accepts_first_responder<H: WindowHandler>(
 }
 
 
-extern "C" fn is_flipped<H: WindowHandler>(
+extern "C" fn property_no<H: WindowHandler>(
     _this: &Object,
     _sel: Sel,
 ) -> BOOL {

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -40,6 +40,10 @@ pub(super) unsafe fn create_view<H: WindowHandler>(
         sel!(preservesContentInLiveResize),
         property_no::<H> as extern "C" fn(&Object, Sel) -> BOOL
     );
+    class.add_method(
+        sel!(acceptsFirstMouse:),
+        accepts_first_mouse::<H> as extern "C" fn(&Object, Sel, id) -> BOOL
+    );
 
     class.add_method(
         sel!(dealloc),
@@ -144,6 +148,15 @@ extern "C" fn property_yes<H: WindowHandler>(
 extern "C" fn property_no<H: WindowHandler>(
     _this: &Object,
     _sel: Sel,
+) -> BOOL {
+    YES
+}
+
+
+extern "C" fn accepts_first_mouse<H: WindowHandler>(
+    _this: &Object,
+    _sel: Sel,
+    _event: id
 ) -> BOOL {
     YES
 }

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -285,8 +285,6 @@ extern "C" fn mouse_moved<H: WindowHandler>(
     _sel: Sel,
     event: id
 ){
-    let state: &mut WindowState<H> = WindowState::from_field(this);
-
     let point: NSPoint = unsafe {
         let point = NSEvent::locationInWindow(event);
 
@@ -300,6 +298,10 @@ extern "C" fn mouse_moved<H: WindowHandler>(
 
     let event = Event::Mouse(MouseEvent::CursorMoved { position });
 
+    let state: &mut WindowState<H> = unsafe {
+        WindowState::from_field(this)
+    };
+
     state.trigger_event(event);
 }
 
@@ -311,7 +313,9 @@ macro_rules! mouse_simple_extern_fn {
             _sel: Sel,
             _event: id,
         ){
-            let state: &mut WindowState<H> = WindowState::from_field(this);
+            let state: &mut WindowState<H> = unsafe {
+                WindowState::from_field(this)
+            };
 
             state.trigger_event(Event::Mouse($event));
         }

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -98,7 +98,7 @@ extern "C" fn mouse_moved<H: WindowHandler>(this: &Object, _sel: Sel, event: id)
 }
 
 
-macro_rules! mouse_click_extern_fn {
+macro_rules! mouse_button_extern_fn {
     ($fn:ident, $event:expr) => {
         extern "C" fn $fn<H: WindowHandler>(this: &Object, _sel: Sel, event: id) {
             let location = unsafe { NSEvent::locationInWindow(event) };
@@ -113,11 +113,11 @@ macro_rules! mouse_click_extern_fn {
 }
 
 
-mouse_click_extern_fn!(left_mouse_down, ButtonPressed(MouseButton::Left));
-mouse_click_extern_fn!(left_mouse_up, ButtonReleased(MouseButton::Left));
+mouse_button_extern_fn!(left_mouse_down, ButtonPressed(MouseButton::Left));
+mouse_button_extern_fn!(left_mouse_up, ButtonReleased(MouseButton::Left));
 
-mouse_click_extern_fn!(right_mouse_down, ButtonPressed(MouseButton::Right));
-mouse_click_extern_fn!(right_mouse_up, ButtonReleased(MouseButton::Right));
+mouse_button_extern_fn!(right_mouse_down, ButtonPressed(MouseButton::Right));
+mouse_button_extern_fn!(right_mouse_up, ButtonReleased(MouseButton::Right));
 
-mouse_click_extern_fn!(middle_mouse_down, ButtonPressed(MouseButton::Middle));
-mouse_click_extern_fn!(middle_mouse_up, ButtonReleased(MouseButton::Middle));
+mouse_button_extern_fn!(middle_mouse_down, ButtonPressed(MouseButton::Middle));
+mouse_button_extern_fn!(middle_mouse_up, ButtonReleased(MouseButton::Middle));

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -140,6 +140,31 @@ unsafe fn create_view_class<H: WindowHandler>() -> &'static Class {
 }
 
 
+extern "C" fn property_yes<H: WindowHandler>(
+    _this: &Object,
+    _sel: Sel,
+) -> BOOL {
+    YES
+}
+
+
+extern "C" fn property_no<H: WindowHandler>(
+    _this: &Object,
+    _sel: Sel,
+) -> BOOL {
+    YES
+}
+
+
+extern "C" fn accepts_first_mouse<H: WindowHandler>(
+    _this: &Object,
+    _sel: Sel,
+    _event: id
+) -> BOOL {
+    YES
+}
+
+
 extern "C" fn release<H: WindowHandler>(this: &Object, _sel: Sel) {
     unsafe {
         let superclass = msg_send![this, superclass];
@@ -163,31 +188,6 @@ extern "C" fn release<H: WindowHandler>(this: &Object, _sel: Sel) {
             ::objc::runtime::objc_disposeClassPair(class);
         }
     }
-}
-
-
-extern "C" fn property_yes<H: WindowHandler>(
-    _this: &Object,
-    _sel: Sel,
-) -> BOOL {
-    YES
-}
-
-
-extern "C" fn property_no<H: WindowHandler>(
-    _this: &Object,
-    _sel: Sel,
-) -> BOOL {
-    YES
-}
-
-
-extern "C" fn accepts_first_mouse<H: WindowHandler>(
-    _this: &Object,
-    _sel: Sel,
-    _event: id
-) -> BOOL {
-    YES
 }
 
 

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -195,7 +195,7 @@ extern "C" fn accepts_first_mouse<H: WindowHandler>(
 /// https://developer.apple.com/documentation/appkit/nstrackingarea/options
 /// https://developer.apple.com/documentation/appkit/nstrackingareaoptions
 unsafe fn reinit_tracking_area(this: &Object, tracking_area: *mut Object){
-    let option_u32: u32 = {
+    let options: usize = {
         let mouse_entered_and_exited = 0x01;
         let tracking_mouse_moved = 0x02;
         let tracking_cursor_update = 0x04;
@@ -212,7 +212,7 @@ unsafe fn reinit_tracking_area(this: &Object, tracking_area: *mut Object){
 
     *tracking_area = msg_send![tracking_area,
         initWithRect:bounds
-        options:option_u32
+        options:options
         owner:this
         userInfo:nil
     ];

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -147,7 +147,7 @@ macro_rules! key_extern_fn {
 
             for c in characters.chars() {
                 let event = Event::Keyboard($event_variant(c as u32));
-                state.window_handler.on_event(&mut state.window, event);
+                state.trigger_event(event);
             }
         }
     };
@@ -174,7 +174,7 @@ extern "C" fn mouse_moved<H: WindowHandler>(this: &Object, _sel: Sel, event: id)
 
     let event = Event::Mouse(MouseEvent::CursorMoved { position });
 
-    state.window_handler.on_event(&mut state.window, event);
+    state.trigger_event(event);
 }
 
 
@@ -183,8 +183,7 @@ macro_rules! mouse_button_extern_fn {
         extern "C" fn $fn<H: WindowHandler>(this: &Object, _sel: Sel, _event: id) {
             let state: &mut WindowState<H> = WindowState::from_field(this);
 
-            let event = Event::Mouse($event);
-            state.window_handler.on_event(&mut state.window, event);
+            state.trigger_event(Event::Mouse($event));
         }
     };
 }

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -293,7 +293,7 @@ extern "C" fn mouse_moved<H: WindowHandler>(this: &Object, _sel: Sel, event: id)
 }
 
 
-macro_rules! mouse_button_extern_fn {
+macro_rules! mouse_simple_extern_fn {
     ($fn:ident, $event:expr) => {
         extern "C" fn $fn<H: WindowHandler>(this: &Object, _sel: Sel, _event: id) {
             let state: &mut WindowState<H> = WindowState::from_field(this);
@@ -304,14 +304,14 @@ macro_rules! mouse_button_extern_fn {
 }
 
 
-mouse_button_extern_fn!(left_mouse_down, ButtonPressed(MouseButton::Left));
-mouse_button_extern_fn!(left_mouse_up, ButtonReleased(MouseButton::Left));
+mouse_simple_extern_fn!(left_mouse_down, ButtonPressed(MouseButton::Left));
+mouse_simple_extern_fn!(left_mouse_up, ButtonReleased(MouseButton::Left));
 
-mouse_button_extern_fn!(right_mouse_down, ButtonPressed(MouseButton::Right));
-mouse_button_extern_fn!(right_mouse_up, ButtonReleased(MouseButton::Right));
+mouse_simple_extern_fn!(right_mouse_down, ButtonPressed(MouseButton::Right));
+mouse_simple_extern_fn!(right_mouse_up, ButtonReleased(MouseButton::Right));
 
-mouse_button_extern_fn!(middle_mouse_down, ButtonPressed(MouseButton::Middle));
-mouse_button_extern_fn!(middle_mouse_up, ButtonReleased(MouseButton::Middle));
+mouse_simple_extern_fn!(middle_mouse_down, ButtonPressed(MouseButton::Middle));
+mouse_simple_extern_fn!(middle_mouse_up, ButtonReleased(MouseButton::Middle));
 
-mouse_button_extern_fn!(mouse_entered, MouseEvent::CursorEntered);
-mouse_button_extern_fn!(mouse_exited, MouseEvent::CursorLeft);
+mouse_simple_extern_fn!(mouse_entered, MouseEvent::CursorEntered);
+mouse_simple_extern_fn!(mouse_exited, MouseEvent::CursorLeft);

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -19,7 +19,7 @@ use crate::MouseEvent::{ButtonPressed, ButtonReleased};
 use super::window::{WindowState, WINDOW_STATE_IVAR_NAME};
 
 
-pub(super) unsafe fn create_subview<H: WindowHandler>(
+pub(super) unsafe fn create_view<H: WindowHandler>(
     window_options: &WindowOpenOptions,
 ) -> id {
     let mut class = ClassDecl::new("BaseviewNSView", class!(NSView))
@@ -69,16 +69,16 @@ pub(super) unsafe fn create_subview<H: WindowHandler>(
     class.add_ivar::<*mut c_void>(WINDOW_STATE_IVAR_NAME);
 
     let class = class.register();
-    let subview: id = msg_send![class, alloc];
+    let view: id = msg_send![class, alloc];
 
     let size = window_options.size;
 
-    subview.initWithFrame_(NSRect::new(
+    view.initWithFrame_(NSRect::new(
         NSPoint::new(0., 0.),
         NSSize::new(size.width, size.height),
     ));
 
-    subview
+    view
 }
 
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -10,7 +10,7 @@ use cocoa::appkit::{
     NSApplicationActivationPolicyRegular, NSBackingStoreBuffered,
     NSRunningApplication, NSWindow, NSWindowStyleMask,
 };
-use cocoa::base::{id, nil, NO, YES};
+use cocoa::base::{id, nil, NO};
 use cocoa::foundation::{NSAutoreleasePool, NSPoint, NSRect, NSSize, NSString};
 
 use objc::{msg_send, runtime::Object, sel, sel_impl};
@@ -62,12 +62,9 @@ impl Window {
         let mut window = match options.parent {
             Parent::WithParent(parent) => {
                 if let RawWindowHandle::MacOS(handle) = parent {
-                    let ns_window = handle.ns_window as *mut objc::runtime::Object;
                     let ns_view = handle.ns_view as *mut objc::runtime::Object;
 
                     unsafe {
-                        ns_window.setAcceptsMouseMovedEvents_(YES);
-
                         let subview = create_view::<H>(&options);
 
                         let _: id = msg_send![ns_view, addSubview: subview];
@@ -119,7 +116,6 @@ impl Window {
                     ns_window.center();
                     ns_window.setTitle_(NSString::alloc(nil).init_str(&options.title));
                     ns_window.makeKeyAndOrderFront_(nil);
-                    ns_window.setAcceptsMouseMovedEvents_(YES);
 
                     let subview = create_view::<H>(&options);
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -1,6 +1,6 @@
-/// macOS window and event handling
+/// macOS window handling
 ///
-/// Heavily inspired by implementation in https://github.com/antonok-edm/vst_window
+/// Inspired by implementation in https://github.com/antonok-edm/vst_window
 
 use std::ffi::c_void;
 use std::sync::Arc;
@@ -90,11 +90,16 @@ impl Window {
             },
             Parent::None => {
                 let scaling = match options.scale {
-                    WindowScalePolicy::SystemScaleFactor => get_scaling().unwrap_or(1.0),
-                    WindowScalePolicy::ScaleFactor(scale) => scale
+                    WindowScalePolicy::ScaleFactor(scale) => scale,
+                    WindowScalePolicy::SystemScaleFactor => {
+                        get_scaling().unwrap_or(1.0)
+                    },
                 };
         
-                let window_info = WindowInfo::from_logical_size(options.size, scaling);
+                let window_info = WindowInfo::from_logical_size(
+                    options.size,
+                    scaling
+                );
 
                 let rect = NSRect::new(
                     NSPoint::new(0.0, 0.0),
@@ -114,15 +119,21 @@ impl Window {
                         )
                         .autorelease();
                     ns_window.center();
-                    ns_window.setTitle_(NSString::alloc(nil).init_str(&options.title));
+                    ns_window.setTitle_(
+                        NSString::alloc(nil).init_str(&options.title)
+                    );
                     ns_window.makeKeyAndOrderFront_(nil);
 
                     let subview = create_view::<H>(&options);
 
                     ns_window.setContentView_(subview);
 
-                    let current_app = NSRunningApplication::currentApplication(nil);
-                    current_app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps);
+                    let current_app = NSRunningApplication::currentApplication(
+                        nil
+                    );
+                    current_app.activateWithOptions_(
+                        NSApplicationActivateIgnoringOtherApps
+                    );
 
                     Window {
                         ns_window: Some(ns_window),
@@ -194,6 +205,7 @@ unsafe impl HasRawWindowHandle for Window {
         })
     }
 }
+
 
 fn get_scaling() -> Option<f64> {
     // TODO: find system scaling

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -79,7 +79,14 @@ impl Window {
                 }
             },
             Parent::AsIfParented => {
-                unimplemented!()
+                let ns_view = unsafe {
+                    create_subview::<H>(&options)
+                };
+
+                Window {
+                    ns_window: None,
+                    ns_view,
+                }
             },
             Parent::None => {
                 let scaling = match options.scale {

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -18,8 +18,8 @@ use objc::{msg_send, runtime::Object, sel, sel_impl};
 use raw_window_handle::{macos::MacOSHandle, HasRawWindowHandle, RawWindowHandle};
 
 use crate::{
-    Event, MouseEvent, WindowHandler, WindowOpenOptions, WindowScalePolicy,
-    WindowInfo, Parent, Size, Point
+    Event, Parent, Size, WindowHandler, WindowOpenOptions, WindowScalePolicy,
+    WindowInfo
 };
 
 use super::view::create_view;
@@ -179,17 +179,6 @@ impl <H: WindowHandler>WindowState<H> {
             let state_ptr: *mut c_void = *obj.get_ivar(WINDOW_STATE_IVAR_NAME);
             &mut *(state_ptr as *mut Self)
         }
-    }
-
-    pub(super) fn trigger_cursor_moved(&mut self, location: NSPoint){
-        let position = Point {
-            x: (location.x / self.size.width),
-            y: 1.0 - (location.y / self.size.height),
-        };
-
-        let event = Event::Mouse(MouseEvent::CursorMoved { position });
-
-        self.window_handler.on_event(&mut self.window, event);
     }
 }
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -18,7 +18,7 @@ use objc::{msg_send, runtime::Object, sel, sel_impl};
 use raw_window_handle::{macos::MacOSHandle, HasRawWindowHandle, RawWindowHandle};
 
 use crate::{
-    Event, Parent, Size, WindowHandler, WindowOpenOptions, WindowScalePolicy,
+    Event, Parent, WindowHandler, WindowOpenOptions, WindowScalePolicy,
     WindowInfo
 };
 
@@ -137,7 +137,6 @@ impl Window {
         let window_state_arc = Arc::new(WindowState {
             window,
             window_handler,
-            size: options.size
         });
 
         let window_state_pointer = Arc::into_raw(
@@ -159,7 +158,6 @@ impl Window {
 pub(super) struct WindowState<H: WindowHandler> {
     window: Window,
     window_handler: H,
-    size: Size,
 }
 
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -24,7 +24,8 @@ use crate::{
 use super::view::create_view;
 
 
-/// Name of the field used to store the `WindowState` pointer in the `BaseviewNSView` class.
+/// Name of the field used to store the `WindowState` pointer in the custom
+/// view class.
 pub(super) const WINDOW_STATE_IVAR_NAME: &str = "WINDOW_STATE_IVAR_NAME";
 
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -8,19 +8,36 @@ use cocoa::appkit::{
 use cocoa::base::{id, nil, NO};
 use cocoa::foundation::{NSAutoreleasePool, NSPoint, NSRect, NSSize, NSString};
 
+use objc::{
+    class,
+    declare::ClassDecl,
+    msg_send,
+    runtime::{Class, Object, Sel},
+    sel, sel_impl,
+};
+
 use raw_window_handle::{macos::MacOSHandle, HasRawWindowHandle, RawWindowHandle};
 
 use crate::{
     Event, KeyboardEvent, MouseButton, MouseEvent, ScrollDelta, WindowEvent, WindowHandler,
-    WindowOpenOptions, WindowScalePolicy, WindowInfo,
+    WindowOpenOptions, WindowScalePolicy, WindowInfo, Parent, Size, Point
 };
+
+
+/// Name of the field used to store the `EventDelegate` pointer in the `EventSubview` class.
+const EVENT_DELEGATE_IVAR: &str = "EVENT_DELEGATE_IVAR";
+
 
 pub struct Window {
     ns_window: id,
     ns_view: id,
 }
 
-pub struct WindowHandle;
+
+pub struct WindowHandle {
+    subview: EventSubview,
+}
+
 
 impl WindowHandle {
     pub fn app_run_blocking(self) {
@@ -38,51 +55,178 @@ impl Window {
               B: FnOnce(&mut Window) -> H,
               B: Send + 'static
     {
+        let _pool = unsafe { NSAutoreleasePool::new(nil) };
+
+        let mut window = match options.parent {
+            Parent::WithParent(parent) => {
+                match parent {
+                    RawWindowHandle::MacOS(handle) => {
+                        let ns_window = handle.ns_window as *mut objc::runtime::Object;
+                        let ns_view = handle.ns_view as *mut objc::runtime::Object;
+
+                        Window {
+                            ns_window,
+                            ns_view,
+                        }
+                    },
+                    _ => {
+                        panic!("Not a macOS window");
+                    }
+                }
+            },
+            Parent::AsIfParented => {
+                unimplemented!()
+            },
+            Parent::None => {
+                let scaling = match options.scale {
+                    WindowScalePolicy::SystemScaleFactor => get_scaling().unwrap_or(1.0),
+                    WindowScalePolicy::ScaleFactor(scale) => scale
+                };
+        
+                let window_info = WindowInfo::from_logical_size(options.size, scaling);
+
+                let rect = NSRect::new(
+                    NSPoint::new(0.0, 0.0),
+                    NSSize::new(
+                        window_info.logical_size().width as f64,
+                        window_info.logical_size().height as f64
+                    ),
+                );
+
+                unsafe {
+                    let ns_window = NSWindow::alloc(nil)
+                        .initWithContentRect_styleMask_backing_defer_(
+                            rect,
+                            NSWindowStyleMask::NSTitledWindowMask,
+                            NSBackingStoreBuffered,
+                            NO,
+                        )
+                        .autorelease();
+                    ns_window.center();
+                    ns_window.setTitle_(NSString::alloc(nil).init_str(&options.title));
+                    ns_window.makeKeyAndOrderFront_(nil);
+
+                    let ns_view = NSView::alloc(nil).init();
+                    ns_window.setContentView_(ns_view);
+
+                    let current_app = NSRunningApplication::currentApplication(nil);
+                    current_app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps);
+
+                    Window {
+                        ns_window,
+                        ns_view,
+                    }
+                }
+            },
+        };
+
+        let handler = build(&mut window);
+
+        let subview = Self::setup_event_delegate(options, window, handler);
+
+        WindowHandle {
+            subview,
+        }
+    }
+
+    fn setup_event_delegate<H: WindowHandler>(
+        window_options: WindowOpenOptions,
+        window: Window,
+        window_handler: H
+    ) -> EventSubview {
         unsafe {
-            let _pool = NSAutoreleasePool::new(nil);
+            let mut class = ClassDecl::new("EventSubview", class!(NSView)).unwrap();
 
-            let scaling = match options.scale {
-                WindowScalePolicy::SystemScaleFactor => get_scaling().unwrap_or(1.0),
-                WindowScalePolicy::ScaleFactor(scale) => scale
-            };
-    
-            let window_info = WindowInfo::from_logical_size(options.size, scaling);
+            class.add_method(sel!(dealloc), dealloc::<H> as extern "C" fn(&Object, Sel));
 
-            let rect = NSRect::new(
-                NSPoint::new(0.0, 0.0),
-                NSSize::new(
-                    window_info.logical_size().width as f64,
-                    window_info.logical_size().height as f64
-                ),
+            class.add_method(
+                sel!(mouseDown:),
+                mouse_down::<H> as extern "C" fn(&Object, Sel, id),
             );
 
-            let ns_window = NSWindow::alloc(nil)
-                .initWithContentRect_styleMask_backing_defer_(
-                    rect,
-                    NSWindowStyleMask::NSTitledWindowMask,
-                    NSBackingStoreBuffered,
-                    NO,
-                )
-                .autorelease();
-            ns_window.center();
-            ns_window.setTitle_(NSString::alloc(nil).init_str(&options.title));
-            ns_window.makeKeyAndOrderFront_(nil);
+            class.add_ivar::<*mut c_void>(EVENT_DELEGATE_IVAR);
 
-            let ns_view = NSView::alloc(nil).init();
-            ns_window.setContentView_(ns_view);
+            let class = class.register();
+            let event_subview: id = msg_send![class, alloc];
 
-            let mut window = Window { ns_window, ns_view };
+            let size = window_options.size;
 
-            let handler = build(&mut window);
+            event_subview.initWithFrame_(NSRect::new(
+                NSPoint::new(0., 0.),
+                NSSize::new(size.width, size.height),
+            ));
+            let _: id = msg_send![window.ns_view, addSubview: event_subview];
 
-            // FIXME: only do this in the unparented case
-            let current_app = NSRunningApplication::currentApplication(nil);
-            current_app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps);
+            let event_delegate = EventDelegate {
+                window,
+                window_handler,
+                size
+            };
 
-            WindowHandle
+            let event_delegate_reference = Box::into_raw(Box::new(event_delegate));
+
+            (*event_subview).set_ivar(EVENT_DELEGATE_IVAR, event_delegate_reference as *mut c_void);
+
+            EventSubview {
+                id: event_subview
+            }
         }
     }
 }
+
+
+
+struct EventSubview {
+    id: id,
+}
+
+
+struct EventDelegate<H: WindowHandler> {
+    window: Window,
+    window_handler: H,
+    size: Size,
+}
+
+
+impl <H: WindowHandler>EventDelegate<H> {
+    /// Returns a mutable reference to an EventDelegate from an Objective-C callback.
+    ///
+    /// `clippy` has issues with this function signature, making the valid point that this could
+    /// create multiple mutable references to the `EventDelegate`. However, in practice macOS
+    /// blocks for the entire duration of each event callback, so this should be fine.
+    #[allow(clippy::mut_from_ref)]
+    fn from_field(obj: &Object) -> &mut Self {
+        unsafe {
+            let delegate_ptr: *mut c_void = *obj.get_ivar(EVENT_DELEGATE_IVAR);
+            &mut *(delegate_ptr as *mut Self)
+        }
+    }
+}
+
+
+extern "C" fn dealloc<H: WindowHandler>(this: &Object, _sel: Sel) {
+    unsafe {
+        let delegate_ptr: *mut c_void = *this.get_ivar(EVENT_DELEGATE_IVAR);
+        Box::from_raw(delegate_ptr as *mut EventDelegate<H>);
+    }
+}
+
+
+extern "C" fn mouse_down<H: WindowHandler>(this: &Object, _sel: Sel, event: id) {
+    let location = unsafe { cocoa::appkit::NSEvent::locationInWindow(event) };
+    let delegate: &mut EventDelegate<H> = EventDelegate::from_field(this);
+
+    let position = Point {
+        x: (location.x / delegate.size.width),
+        y: 1.0 - (location.y / delegate.size.height),
+    };
+    let event = Event::Mouse(MouseEvent::CursorMoved { position });
+    delegate.window_handler.on_event(&mut delegate.window, event);
+
+    let event = Event::Mouse(MouseEvent::ButtonPressed(MouseButton::Left));
+    delegate.window_handler.on_event(&mut delegate.window, event);
+}
+
 
 unsafe impl HasRawWindowHandle for Window {
     fn raw_window_handle(&self) -> RawWindowHandle {

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -131,9 +131,12 @@ impl Window {
                         )
                         .autorelease();
                     ns_window.center();
-                    ns_window.setTitle_(
-                        NSString::alloc(nil).init_str(&options.title)
-                    );
+
+                    let title = NSString::alloc(nil)
+                        .init_str(&options.title)
+                        .autorelease();
+                    ns_window.setTitle_(title);
+
                     ns_window.makeKeyAndOrderFront_(nil);
 
                     let subview = create_view::<H>(&options);

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -6,9 +6,8 @@ use std::ffi::c_void;
 use std::sync::Arc;
 
 use cocoa::appkit::{
-    NSApp, NSApplication, NSApplicationActivateIgnoringOtherApps,
-    NSApplicationActivationPolicyRegular, NSBackingStoreBuffered,
-    NSRunningApplication, NSWindow, NSWindowStyleMask,
+    NSApp, NSApplication, NSApplicationActivationPolicyRegular,
+    NSBackingStoreBuffered, NSWindow, NSWindowStyleMask,
 };
 use cocoa::base::{id, nil, NO};
 use cocoa::foundation::{NSAutoreleasePool, NSPoint, NSRect, NSSize, NSString};
@@ -127,13 +126,6 @@ impl Window {
                     let subview = create_view::<H>(&options);
 
                     ns_window.setContentView_(subview);
-
-                    let current_app = NSRunningApplication::currentApplication(
-                        nil
-                    );
-                    current_app.activateWithOptions_(
-                        NSApplicationActivateIgnoringOtherApps
-                    );
 
                     Window {
                         ns_window: Some(ns_window),

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -1,7 +1,11 @@
+/// macOS window and event handling
+///
+/// Heavily inspired by implementation in https://github.com/antonok-edm/vst_window
+
 use std::ffi::c_void;
 
 use cocoa::appkit::{
-    NSApp, NSApplication, NSApplicationActivateIgnoringOtherApps,
+    NSApp, NSApplication, NSApplicationActivateIgnoringOtherApps, NSEvent,
     NSApplicationActivationPolicyRegular, NSBackingStoreBuffered, NSRunningApplication, NSView,
     NSWindow, NSWindowStyleMask,
 };
@@ -199,7 +203,7 @@ extern "C" fn dealloc<H: WindowHandler>(this: &Object, _sel: Sel) {
 
 
 extern "C" fn mouse_down<H: WindowHandler>(this: &Object, _sel: Sel, event: id) {
-    let location = unsafe { cocoa::appkit::NSEvent::locationInWindow(event) };
+    let location = unsafe { NSEvent::locationInWindow(event) };
     let delegate: &mut EventDelegate<H> = EventDelegate::from_field(this);
 
     let position = Point {

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -22,7 +22,7 @@ use crate::{
     WindowInfo, Parent, Size, Point
 };
 
-use super::subview::create_subview;
+use super::view::create_view;
 
 
 /// Name of the field used to store the `WindowState` pointer in the `BaseviewNSView` class.
@@ -65,7 +65,7 @@ impl Window {
                     let ns_view = handle.ns_view as *mut objc::runtime::Object;
 
                     unsafe {
-                        let subview = create_subview::<H>(&options);
+                        let subview = create_view::<H>(&options);
 
                         let _: id = msg_send![ns_view, addSubview: subview];
 
@@ -80,7 +80,7 @@ impl Window {
             },
             Parent::AsIfParented => {
                 let ns_view = unsafe {
-                    create_subview::<H>(&options)
+                    create_view::<H>(&options)
                 };
 
                 Window {
@@ -117,7 +117,7 @@ impl Window {
                     ns_window.setTitle_(NSString::alloc(nil).init_str(&options.title));
                     ns_window.makeKeyAndOrderFront_(nil);
 
-                    let subview = create_subview::<H>(&options);
+                    let subview = create_view::<H>(&options);
 
                     ns_window.setContentView_(subview);
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -134,18 +134,20 @@ impl Window {
 
         let window_handler = build(&mut window);
 
-        let window_state = WindowState {
+        let window_state_arc = Arc::new(WindowState {
             window,
             window_handler,
             size: options.size
-        };
+        });
 
-        let window_state = Arc::new(window_state);
+        let window_state_pointer = Arc::into_raw(
+            window_state_arc.clone()
+        ) as *mut c_void;
 
         unsafe {
-            (*window_state.window.ns_view).set_ivar(
+            (*window_state_arc.window.ns_view).set_ivar(
                 WINDOW_STATE_IVAR_NAME,
-                Arc::into_raw(window_state.clone()) as *mut c_void
+                window_state_pointer
             );
         }
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -10,7 +10,7 @@ use cocoa::appkit::{
     NSApplicationActivationPolicyRegular, NSBackingStoreBuffered,
     NSRunningApplication, NSWindow, NSWindowStyleMask,
 };
-use cocoa::base::{id, nil, NO};
+use cocoa::base::{id, nil, NO, YES};
 use cocoa::foundation::{NSAutoreleasePool, NSPoint, NSRect, NSSize, NSString};
 
 use objc::{msg_send, runtime::Object, sel, sel_impl};
@@ -62,9 +62,12 @@ impl Window {
         let mut window = match options.parent {
             Parent::WithParent(parent) => {
                 if let RawWindowHandle::MacOS(handle) = parent {
+                    let ns_window = handle.ns_window as *mut objc::runtime::Object;
                     let ns_view = handle.ns_view as *mut objc::runtime::Object;
 
                     unsafe {
+                        ns_window.setAcceptsMouseMovedEvents_(YES);
+
                         let subview = create_view::<H>(&options);
 
                         let _: id = msg_send![ns_view, addSubview: subview];
@@ -116,6 +119,7 @@ impl Window {
                     ns_window.center();
                     ns_window.setTitle_(NSString::alloc(nil).init_str(&options.title));
                     ns_window.makeKeyAndOrderFront_(nil);
+                    ns_window.setAcceptsMouseMovedEvents_(YES);
 
                     let subview = create_view::<H>(&options);
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -208,7 +208,7 @@ impl <H: WindowHandler>WindowState<H> {
 extern "C" fn dealloc<H: WindowHandler>(this: &Object, _sel: Sel) {
     unsafe {
         let state_ptr: *mut c_void = *this.get_ivar(WINDOW_STATE_IVAR_NAME);
-        Box::from_raw(state_ptr as *mut WindowState<H>);
+        Arc::from_raw(state_ptr as *mut WindowState<H>);
     }
 }
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -43,9 +43,9 @@ pub struct WindowHandle;
 impl WindowHandle {
     pub fn app_run_blocking(self) {
         unsafe {
-            let app = NSApp();
-            app.setActivationPolicy_(NSApplicationActivationPolicyRegular);
-            app.run();
+            // Get reference to already created shared NSApplication object
+            // and run the main loop
+            NSApp().run();
         }
     }
 }
@@ -88,6 +88,18 @@ impl Window {
                 }
             },
             Parent::None => {
+                // It seems prudent to run NSApp() here before doing other
+                // work. It runs [NSApplication sharedApplication], which is
+                // what is run at the very start of the Xcode-generated main
+                // function of a cocoa app according to:
+                // https://developer.apple.com/documentation/appkit/nsapplication
+                unsafe {
+                    let app = NSApp();
+                    app.setActivationPolicy_(
+                        NSApplicationActivationPolicyRegular
+                    );
+                }
+
                 let scaling = match options.scale {
                     WindowScalePolicy::ScaleFactor(scale) => scale,
                     WindowScalePolicy::SystemScaleFactor => {

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -161,8 +161,8 @@ impl Window {
 
 
 pub(super) struct WindowState<H: WindowHandler> {
-    pub(super) window: Window,
-    pub(super) window_handler: H,
+    window: Window,
+    window_handler: H,
     size: Size,
 }
 
@@ -179,6 +179,10 @@ impl <H: WindowHandler>WindowState<H> {
             let state_ptr: *mut c_void = *obj.get_ivar(WINDOW_STATE_IVAR_NAME);
             &mut *(state_ptr as *mut Self)
         }
+    }
+
+    pub(super) fn trigger_event(&mut self, event: Event){
+        self.window_handler.on_event(&mut self.window, event);
     }
 }
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -200,8 +200,8 @@ impl <H: WindowHandler>WindowState<H> {
 
 unsafe impl HasRawWindowHandle for Window {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        let ns_window = self.ns_window.unwrap_or_else(
-            ::std::ptr::null_mut
+        let ns_window = self.ns_window.unwrap_or(
+            ::std::ptr::null_mut()
         ) as *mut c_void;
 
         RawWindowHandle::MacOS(MacOSHandle {

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -12,7 +12,7 @@ use objc::{
     class,
     declare::ClassDecl,
     msg_send,
-    runtime::{Class, Object, Sel},
+    runtime::{Object, Sel},
     sel, sel_impl,
 };
 
@@ -34,9 +34,7 @@ pub struct Window {
 }
 
 
-pub struct WindowHandle {
-    subview: EventSubview,
-}
+pub struct WindowHandle;
 
 
 impl WindowHandle {
@@ -122,18 +120,16 @@ impl Window {
 
         let handler = build(&mut window);
 
-        let subview = Self::setup_event_delegate(options, window, handler);
+        Self::setup_event_delegate(options, window, handler);
 
-        WindowHandle {
-            subview,
-        }
+        WindowHandle
     }
 
     fn setup_event_delegate<H: WindowHandler>(
         window_options: WindowOpenOptions,
         window: Window,
         window_handler: H
-    ) -> EventSubview {
+    ){
         unsafe {
             let mut class = ClassDecl::new("EventSubview", class!(NSView)).unwrap();
 
@@ -166,18 +162,8 @@ impl Window {
             let event_delegate_reference = Box::into_raw(Box::new(event_delegate));
 
             (*event_subview).set_ivar(EVENT_DELEGATE_IVAR, event_delegate_reference as *mut c_void);
-
-            EventSubview {
-                id: event_subview
-            }
         }
     }
-}
-
-
-
-struct EventSubview {
-    id: id,
 }
 
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -181,17 +181,15 @@ pub(super) struct WindowState<H: WindowHandler> {
 
 
 impl <H: WindowHandler>WindowState<H> {
-    /// Returns a mutable reference to an WindowState from an Objective-C callback.
+    /// Returns a mutable reference to a WindowState from an Objective-C field
     ///
-    /// `clippy` has issues with this function signature, making the valid point that this could
-    /// create multiple mutable references to the `WindowState`. However, in practice macOS
-    /// blocks for the entire duration of each event callback, so this should be fine.
-    #[allow(clippy::mut_from_ref)]
-    pub(super) fn from_field(obj: &Object) -> &mut Self {
-        unsafe {
-            let state_ptr: *mut c_void = *obj.get_ivar(WINDOW_STATE_IVAR_NAME);
-            &mut *(state_ptr as *mut Self)
-        }
+    /// Don't use this to create two simulataneous references to a single
+    /// WindowState. Apparently, macOS blocks for the duration of an event,
+    /// callback, meaning that this shouldn't be a problem in practice.
+    pub(super) unsafe fn from_field(obj: &Object) -> &mut Self {
+        let state_ptr: *mut c_void = *obj.get_ivar(WINDOW_STATE_IVAR_NAME);
+
+        &mut *(state_ptr as *mut Self)
     }
 
     pub(super) fn trigger_event(&mut self, event: Event){


### PR DESCRIPTION
Adds barebones handling of mouse down events on macOS (#51) with a lot of code from https://github.com/antonok-edm/vst_window. The open_window example works.

Possible problems that I can think of:

- No reference to the created Window is stored in the WindowHandle, which means it can't be accessed later and cleanup must be handled by macOS (?).
- Parent window functionality has not been tested
- AsIfParented support is not implemented

If this looks like something we could make use of, I can have a look at implementing other events as well.