### PR TITLE
Ignore unknown X11 events

### DIFF
--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -411,6 +411,10 @@ impl Window {
                 );
             }
 
+            x if x > (x11::xlib::LASTEvent as u8) => {
+                // Gobble up unspecified event
+            }
+
             _ => {
                 println!("Unhandled event type: {:?}", event_type);
             }


### PR DESCRIPTION
I am getting many (many) `Unhandled event type: 65` prints when testing my GUI.
That event number is way beyond the defined X11 events, and I guess it makes
sense to just not print anything for these events for now.