### PR TITLE
remove WindowHandle

### DIFF
--- a/examples/open_window.rs
+++ b/examples/open_window.rs
@@ -39,7 +39,7 @@ fn main() {
 
     let (mut tx, rx) = RingBuffer::new(128).split();
 
-    let (_handle, opt_app_runner) = Window::open(
+    let opt_app_runner = Window::open(
         window_open_options,
         |_| OpenWindowExample { rx }
     );

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -29,15 +29,6 @@ pub(super) const WINDOW_STATE_IVAR_NAME: &str = "WINDOW_STATE_IVAR_NAME";
 pub(super) const FRAME_TIMER_IVAR_NAME: &str = "FRAME_TIMER";
 
 
-pub struct Window {
-    /// Only set if we created the parent window, i.e. we are running in
-    /// parentless mode
-    ns_window: Option<id>,
-    /// Our subclassed NSView
-    ns_view: id,
-}
-
-
 pub struct AppRunner;
 
 impl AppRunner {
@@ -51,14 +42,19 @@ impl AppRunner {
 }
 
 
-pub struct WindowHandle;
-
+pub struct Window {
+    /// Only set if we created the parent window, i.e. we are running in
+    /// parentless mode
+    ns_window: Option<id>,
+    /// Our subclassed NSView
+    ns_view: id,
+}
 
 impl Window {
     pub fn open<H, B>(
         options: WindowOpenOptions,
         build: B
-    ) -> (crate::WindowHandle, Option<crate::AppRunner>)
+    ) -> Option<crate::AppRunner>
         where H: WindowHandler + 'static,
               B: FnOnce(&mut crate::Window) -> H,
               B: Send + 'static
@@ -201,9 +197,7 @@ impl Window {
             )
         }
 
-        let window_handle = crate::WindowHandle(WindowHandle);
-
-        (window_handle, opt_app_runner)
+        opt_app_runner
     }
 }
 

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -195,8 +195,6 @@ pub struct Window {
     hwnd: HWND,
 }
 
-pub struct WindowHandle;
-
 pub struct AppRunner {
     hwnd: HWND,
 }
@@ -224,7 +222,7 @@ impl Window {
     pub fn open<H, B>(
         options: WindowOpenOptions,
         build: B
-    ) -> (crate::WindowHandle, Option<crate::AppRunner>)
+    ) -> Option<crate::AppRunner>
         where H: WindowHandler + 'static,
               B: FnOnce(&mut crate::Window) -> H,
               B: Send + 'static
@@ -301,15 +299,11 @@ impl Window {
             SetWindowLongPtrA(hwnd, GWLP_USERDATA, Box::into_raw(window_state) as *const _ as _);
             SetTimer(hwnd, WIN_FRAME_TIMER, 15, None);
 
-            let window_handle = crate::WindowHandle(WindowHandle);
-
-            let opt_app_runner = if let crate::Parent::None = options.parent {
+            if let crate::Parent::None = options.parent {
                 Some(crate::AppRunner(AppRunner { hwnd }))
             } else {
                 None
-            };
-
-            (window_handle, opt_app_runner)
+            }
         }
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -18,15 +18,13 @@ impl AppRunner {
     }
 }
 
-pub struct WindowHandle(pub(crate) platform::WindowHandle);
-
 pub struct Window<'a>(pub(crate) &'a mut platform::Window);
 
 impl<'a> Window<'a> {
     pub fn open<H, B>(
         options: WindowOpenOptions,
         build: B
-    ) -> (WindowHandle, Option<AppRunner>)
+    ) -> Option<AppRunner>
         where H: WindowHandler + 'static,
               B: FnOnce(&mut Window) -> H,
               B: Send + 'static
@@ -39,24 +37,4 @@ unsafe impl<'a> HasRawWindowHandle for Window<'a> {
     fn raw_window_handle(&self) -> RawWindowHandle {
         self.0.raw_window_handle()
     }
-}
-
-// Compile-time API assertions
-#[doc(hidden)]
-mod assertions {
-    use crate::{WindowHandle, WindowHandler, Event, Window};
-
-    struct TestWindowHandler {
-        #[allow(dead_code)]
-        ptr: *mut ::std::ffi::c_void,
-    }
-
-    impl WindowHandler for TestWindowHandler {
-        fn on_event(&mut self, _: &mut Window, _: Event) {}
-        fn on_frame(&mut self) {}
-    }
-
-    // Assert that WindowHandle is Send even if WindowHandler isn't
-    static_assertions::assert_not_impl_any!(TestWindowHandler: Send);
-    static_assertions::assert_impl_all!(WindowHandle: Send);
 }

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -49,7 +49,7 @@ impl Window {
     pub fn open<H, B>(
         options: WindowOpenOptions,
         build: B
-    ) -> (crate::WindowHandle, Option<crate::AppRunner>)
+    ) -> Option<crate::AppRunner>
         where H: WindowHandler,
               B: FnOnce(&mut crate::Window) -> H,
               B: Send + 'static
@@ -67,15 +67,11 @@ impl Window {
         // FIXME: placeholder types for returning errors in the future
         let _ = rx.recv();
 
-        let window_handle = crate::WindowHandle(WindowHandle);
-
-        let opt_app_runner = if is_not_parented {
+        if is_not_parented {
             Some(crate::AppRunner(AppRunner { thread }))
         } else {
             None
-        };
-
-        (window_handle, opt_app_runner)
+        }
     }
 
     fn window_thread<H, B>(


### PR DESCRIPTION
Remove WindowHandle since we don't have immediate plans to use it for anything. We can reintroduce it if it's necessary.

(merge after #73)