### PR TITLE
break up Window::open() into separate functions

### DIFF
--- a/examples/open_window.rs
+++ b/examples/open_window.rs
@@ -34,15 +34,9 @@ fn main() {
         title: "baseview".into(),
         size: baseview::Size::new(512.0, 512.0),
         scale: WindowScalePolicy::SystemScaleFactor,
-        parent: baseview::Parent::None,
     };
 
     let (mut tx, rx) = RingBuffer::new(128).split();
-
-    let opt_app_runner = Window::open(
-        window_open_options,
-        |_| OpenWindowExample { rx }
-    );
 
     ::std::thread::spawn(move || {
         loop {
@@ -54,5 +48,8 @@ fn main() {
         }
     });
 
-    opt_app_runner.unwrap().app_run_blocking();
+    Window::open_blocking(
+        window_open_options,
+        |_| OpenWindowExample { rx }
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-use raw_window_handle::RawWindowHandle;
-
 #[cfg(target_os = "windows")]
 mod win;
 #[cfg(target_os = "linux")]
@@ -19,17 +17,3 @@ pub use mouse_cursor::MouseCursor;
 pub use window::*;
 pub use window_info::*;
 pub use window_open_options::*;
-
-#[derive(Debug)]
-pub enum Parent {
-    None,
-    AsIfParented,
-    WithParent(RawWindowHandle),
-}
-
-unsafe impl Send for Parent {}
-
-pub trait WindowHandler {
-    fn on_frame(&mut self);
-    fn on_event(&mut self, window: &mut Window, event: Event);
-}

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -17,25 +17,11 @@ use objc::{msg_send, runtime::Object, sel, sel_impl};
 use raw_window_handle::{macos::MacOSHandle, HasRawWindowHandle, RawWindowHandle};
 
 use crate::{
-    Event, Parent, WindowHandler, WindowOpenOptions,
-    WindowScalePolicy, WindowInfo
+    Event, WindowHandler, WindowOpenOptions, WindowScalePolicy, WindowInfo,
 };
 
 use super::view::{create_view, BASEVIEW_STATE_IVAR};
 use super::keyboard::KeyboardState;
-
-
-pub struct AppRunner;
-
-impl AppRunner {
-    pub fn app_run_blocking(self) {
-        unsafe {
-            // Get reference to already created shared NSApplication object
-            // and run the main loop
-            NSApp().run();
-        }
-    }
-}
 
 
 pub struct Window {
@@ -47,102 +33,147 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn open<H, B>(
-        options: WindowOpenOptions,
-        build: B
-    ) -> Option<crate::AppRunner>
-        where H: WindowHandler + 'static,
-              B: FnOnce(&mut crate::Window) -> H,
-              B: Send + 'static
+    pub fn open_parented<P, H, B>(parent: &P, options: WindowOpenOptions, build: B)
+    where
+        P: HasRawWindowHandle,
+        H: WindowHandler + 'static,
+        B: FnOnce(&mut crate::Window) -> H,
+        B: Send + 'static,
     {
         let _pool = unsafe { NSAutoreleasePool::new(nil) };
 
-        let mut window = unsafe {
-            Window {
-                ns_window: None,
-                ns_view: create_view(&options),
-            }
+        let handle = if let RawWindowHandle::MacOS(handle) = parent.raw_window_handle() {
+            handle
+        } else {
+            panic!("Not a macOS window");
         };
 
+        let ns_view = unsafe { create_view(&options) };
+
+        let window = Window {
+            ns_window: None,
+            ns_view,
+        };
+
+        Self::init(window, build);
+
+        unsafe {
+            let _: id = msg_send![handle.ns_view as *mut Object, addSubview: ns_view];
+        }
+    }
+
+    pub fn open_as_if_parented<H, B>(options: WindowOpenOptions, build: B) -> RawWindowHandle
+    where
+        H: WindowHandler + 'static,
+        B: FnOnce(&mut crate::Window) -> H,
+        B: Send + 'static,
+    {
+        let _pool = unsafe { NSAutoreleasePool::new(nil) };
+
+        let ns_view = unsafe { create_view(&options) };
+
+        let window = Window {
+            ns_window: None,
+            ns_view,
+        };
+
+        let raw_window_handle = window.raw_window_handle();
+
+        Self::init(window, build);
+
+        raw_window_handle
+    }
+
+    pub fn open_blocking<H, B>(options: WindowOpenOptions, build: B)
+    where
+        H: WindowHandler + 'static,
+        B: FnOnce(&mut crate::Window) -> H,
+        B: Send + 'static,
+    {
+        let _pool = unsafe { NSAutoreleasePool::new(nil) };
+
+        // It seems prudent to run NSApp() here before doing other
+        // work. It runs [NSApplication sharedApplication], which is
+        // what is run at the very start of the Xcode-generated main
+        // function of a cocoa app according to:
+        // https://developer.apple.com/documentation/appkit/nsapplication
+        let app = unsafe { NSApp() };
+
+        unsafe {
+            app.setActivationPolicy_(
+                NSApplicationActivationPolicyRegular
+            );
+        }
+
+        let scaling = match options.scale {
+            WindowScalePolicy::ScaleFactor(scale) => scale,
+            WindowScalePolicy::SystemScaleFactor => 1.0,
+        };
+        
+        let window_info = WindowInfo::from_logical_size(
+            options.size,
+            scaling
+        );
+
+        let rect = NSRect::new(
+            NSPoint::new(0.0, 0.0),
+            NSSize::new(
+                window_info.logical_size().width as f64,
+                window_info.logical_size().height as f64
+            ),
+        );
+
+        let ns_window = unsafe {
+            let ns_window = NSWindow::alloc(nil)
+                .initWithContentRect_styleMask_backing_defer_(
+                    rect,
+                    NSWindowStyleMask::NSTitledWindowMask,
+                    NSBackingStoreBuffered,
+                    NO,
+                )
+                .autorelease();
+            ns_window.center();
+
+            let title = NSString::alloc(nil)
+                .init_str(&options.title)
+                .autorelease();
+            ns_window.setTitle_(title);
+
+            ns_window.makeKeyAndOrderFront_(nil);
+
+            ns_window
+        };
+
+        let ns_view = unsafe { create_view(&options) };
+
+        let window = Window {
+            ns_window: Some(ns_window),
+            ns_view,
+        };
+
+        Self::init(window, build);
+
+        unsafe {
+            ns_window.setContentView_(ns_view);
+        }
+
+        unsafe {
+            app.run();
+        }
+    }
+
+    fn init<H, B>(
+        mut window: Window,
+        build: B
+    )
+    where H: WindowHandler + 'static,
+          B: FnOnce(&mut crate::Window) -> H,
+          B: Send + 'static,
+    {
         let window_handler = Box::new(build(&mut crate::Window::new(&mut window)));
 
         let retain_count_after_build: usize = unsafe {
             msg_send![window.ns_view, retainCount]
-        };
-
-        let opt_app_runner = match options.parent {
-            Parent::WithParent(RawWindowHandle::MacOS(handle)) => {
-                unsafe {
-                    let () = msg_send![
-                        handle.ns_view as *mut Object,
-                        addSubview: window.ns_view
-                    ];
-                }
-
-                None
-            },
-            Parent::WithParent(_) => {
-                panic!("Not a macOS window");
-            },
-            Parent::AsIfParented => {
-                None
-            },
-            Parent::None => {
-                // It seems prudent to run NSApp() here before doing other
-                // work. It runs [NSApplication sharedApplication], which is
-                // what is run at the very start of the Xcode-generated main
-                // function of a cocoa app according to:
-                // https://developer.apple.com/documentation/appkit/nsapplication
-                unsafe {
-                    let app = NSApp();
-                    app.setActivationPolicy_(
-                        NSApplicationActivationPolicyRegular
-                    );
-                }
-
-                let scaling = match options.scale {
-                    WindowScalePolicy::ScaleFactor(scale) => scale,
-                    WindowScalePolicy::SystemScaleFactor => 1.0,
-                };
-        
-                let window_info = WindowInfo::from_logical_size(
-                    options.size,
-                    scaling
-                );
-
-                let rect = NSRect::new(
-                    NSPoint::new(0.0, 0.0),
-                    NSSize::new(
-                        window_info.logical_size().width as f64,
-                        window_info.logical_size().height as f64
-                    ),
-                );
-
-                unsafe {
-                    let ns_window = NSWindow::alloc(nil)
-                        .initWithContentRect_styleMask_backing_defer_(
-                            rect,
-                            NSWindowStyleMask::NSTitledWindowMask,
-                            NSBackingStoreBuffered,
-                            NO,
-                        )
-                        .autorelease();
-                    ns_window.center();
-
-                    let title = NSString::alloc(nil)
-                        .init_str(&options.title)
-                        .autorelease();
-                    ns_window.setTitle_(title);
-
-                    ns_window.makeKeyAndOrderFront_(nil);
-
-                    ns_window.setContentView_(window.ns_view);
-
-                    window.ns_window = Some(ns_window);
-
-                    Some(crate::AppRunner(AppRunner))
-                }
-            },
         };
 
         let window_state_ptr = Box::into_raw(Box::new(WindowState {
@@ -161,8 +192,6 @@ impl Window {
 
             WindowState::setup_timer(window_state_ptr);
         }
-
-        opt_app_runner
     }
 }
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -64,7 +64,7 @@ impl Window {
             }
         };
 
-        let window_handler = Box::new(build(&mut crate::Window(&mut window)));
+        let window_handler = Box::new(build(&mut crate::Window::new(&mut window)));
 
         let retain_count_after_build: usize = unsafe {
             msg_send![window.ns_view, retainCount]
@@ -190,7 +190,7 @@ impl WindowState {
 
     pub(super) fn trigger_event(&mut self, event: Event){
         self.window_handler.on_event(
-            &mut crate::Window(&mut self.window),
+            &mut crate::Window::new(&mut self.window),
             event
         );
     }

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -67,7 +67,7 @@ unsafe extern "system" fn wnd_proc(
     let window_state_ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut RefCell<WindowState>;
     if !window_state_ptr.is_null() {
         let mut window = Window { hwnd };
-        let mut window = crate::Window(&mut window);
+        let mut window = crate::Window::new(&mut window);
 
         match msg {
             WM_MOUSEMOVE => {
@@ -320,7 +320,7 @@ impl Window {
             );
             // todo: manage error ^
 
-            let handler = Box::new(build(&mut crate::Window(&mut Window { hwnd })));
+            let handler = Box::new(build(&mut crate::Window::new(&mut Window { hwnd })));
 
             let window_state = Box::new(RefCell::new(WindowState {
                 window_class,

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 
 use crate::WindowHandler;
@@ -18,9 +20,20 @@ impl AppRunner {
     }
 }
 
-pub struct Window<'a>(pub(crate) &'a mut platform::Window);
+pub struct Window<'a> {
+    window: &'a mut platform::Window,
+    // so that Window is !Send on all platforms
+    phantom: PhantomData<*mut ()>,
+}
 
 impl<'a> Window<'a> {
+    pub(crate) fn new(window: &mut platform::Window) -> Window {
+        Window {
+            window,
+            phantom: PhantomData,
+        }
+    }
+
     pub fn open<H, B>(
         options: WindowOpenOptions,
         build: B
@@ -35,6 +48,6 @@ impl<'a> Window<'a> {
 
 unsafe impl<'a> HasRawWindowHandle for Window<'a> {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        self.0.raw_window_handle()
+        self.window.raw_window_handle()
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -2,22 +2,19 @@ use std::marker::PhantomData;
 
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 
-use crate::WindowHandler;
+use crate::event::Event;
 use crate::window_open_options::WindowOpenOptions;
 
+#[cfg(target_os = "macos")]
+use crate::macos as platform;
 #[cfg(target_os = "windows")]
 use crate::win as platform;
 #[cfg(target_os = "linux")]
 use crate::x11 as platform;
-#[cfg(target_os = "macos")]
-use crate::macos as platform;
 
-pub struct AppRunner(pub(crate) platform::AppRunner);
-
-impl AppRunner {
-    pub fn app_run_blocking(self){
-        self.0.app_run_blocking();
-    }
+pub trait WindowHandler {
+    fn on_frame(&mut self);
+    fn on_event(&mut self, window: &mut Window, event: Event);
 }
 
 pub struct Window<'a> {
@@ -34,15 +31,32 @@ impl<'a> Window<'a> {
         }
     }
 
-    pub fn open<H, B>(
-        options: WindowOpenOptions,
-        build: B
-    ) -> Option<AppRunner>
-        where H: WindowHandler + 'static,
-              B: FnOnce(&mut Window) -> H,
-              B: Send + 'static
+    pub fn open_parented<P, H, B>(parent: &P, options: WindowOpenOptions, build: B)
+    where
+        P: HasRawWindowHandle,
+        H: WindowHandler + 'static,
+        B: FnOnce(&mut Window) -> H,
+        B: Send + 'static,
     {
-        platform::Window::open::<H, B>(options, build)
+        platform::Window::open_parented::<P, H, B>(parent, options, build)
+    }
+
+    pub fn open_as_if_parented<H, B>(options: WindowOpenOptions, build: B) -> RawWindowHandle
+    where
+        H: WindowHandler + 'static,
+        B: FnOnce(&mut Window) -> H,
+        B: Send + 'static,
+    {
+        platform::Window::open_as_if_parented::<H, B>(options, build)
+    }
+
+    pub fn open_blocking<H, B>(options: WindowOpenOptions, build: B)
+    where
+        H: WindowHandler + 'static,
+        B: FnOnce(&mut Window) -> H,
+        B: Send + 'static,
+    {
+        platform::Window::open_blocking::<H, B>(options, build)
     }
 }
 

--- a/src/window_open_options.rs
+++ b/src/window_open_options.rs
@@ -1,4 +1,4 @@
-use crate::{Parent, Size};
+use crate::Size;
 
 /// The dpi scaling policy of the window
 #[derive(Debug)]
@@ -10,7 +10,6 @@ pub enum WindowScalePolicy {
 }
 
 /// The options for opening a new window
-#[derive(Debug)]
 pub struct WindowOpenOptions {
     pub title: String,
 
@@ -22,6 +21,4 @@ pub struct WindowOpenOptions {
 
     /// The dpi scaling policy
     pub scale: WindowScalePolicy,
-
-    pub parent: Parent,
 }

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -186,7 +186,7 @@ impl Window {
             new_physical_size: None,
         };
 
-        let mut handler = build(&mut crate::Window(&mut window));
+        let mut handler = build(&mut crate::Window::new(&mut window));
 
         let _ = tx.send(Ok(()));
 
@@ -238,7 +238,7 @@ impl Window {
             let window_info = self.window_info;
 
             handler.on_event(
-                &mut crate::Window(self),
+                &mut crate::Window::new(self),
                 Event::Window(WindowEvent::Resized(window_info))
             )
         }
@@ -326,7 +326,7 @@ impl Window {
 
                 if wm_delete_window == data32[0] {
                     handler.on_event(
-                        &mut crate::Window(self),
+                        &mut crate::Window::new(self),
                         Event::Window(WindowEvent::WillClose)
                     );
 
@@ -357,7 +357,7 @@ impl Window {
                     let logical_pos = physical_pos.to_logical(&self.window_info);
 
                     handler.on_event(
-                        &mut crate::Window(self),
+                        &mut crate::Window::new(self),
                         Event::Mouse(MouseEvent::CursorMoved {
                             position: logical_pos,
                         }),
@@ -372,7 +372,7 @@ impl Window {
                 match detail {
                     4 => {
                         handler.on_event(
-                            &mut crate::Window(self),
+                            &mut crate::Window::new(self),
                             Event::Mouse(MouseEvent::WheelScrolled(ScrollDelta::Lines {
                                 x: 0.0,
                                 y: 1.0,
@@ -381,7 +381,7 @@ impl Window {
                     }
                     5 => {
                         handler.on_event(
-                            &mut crate::Window(self),
+                            &mut crate::Window::new(self),
                             Event::Mouse(MouseEvent::WheelScrolled(ScrollDelta::Lines {
                                 x: 0.0,
                                 y: -1.0,
@@ -391,7 +391,7 @@ impl Window {
                     detail => {
                         let button_id = mouse_id(detail);
                         handler.on_event(
-                            &mut crate::Window(self),
+                            &mut crate::Window::new(self),
                             Event::Mouse(MouseEvent::ButtonPressed(button_id))
                         );
                     }
@@ -405,7 +405,7 @@ impl Window {
                 if detail != 4 && detail != 5 {
                     let button_id = mouse_id(detail);
                     handler.on_event(
-                        &mut crate::Window(self),
+                        &mut crate::Window::new(self),
                         Event::Mouse(MouseEvent::ButtonReleased(button_id))
                     );
                 }
@@ -418,7 +418,7 @@ impl Window {
                 let event = unsafe { xcb::cast_event::<xcb::KeyPressEvent>(&event) };
 
                 handler.on_event(
-                    &mut crate::Window(self),
+                    &mut crate::Window::new(self),
                     Event::Keyboard(convert_key_press_event(&event))
                 );
             }
@@ -427,7 +427,7 @@ impl Window {
                 let event = unsafe { xcb::cast_event::<xcb::KeyReleaseEvent>(&event) };
 
                 handler.on_event(
-                    &mut crate::Window(self),
+                    &mut crate::Window::new(self),
                     Event::Keyboard(convert_key_release_event(&event))
                 );
             }


### PR DESCRIPTION
Separate `Window::open()` into `open_parented`, `open_as_if_parented`, and `open_blocking`. `open_as_if_parented` returns a `RawWindowHandle`.