### PR TITLE
Fix: Check for remaining events in the internal X11/xcb buffers

### DIFF
--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -283,6 +283,10 @@ impl Window {
 
             let mut fds = [PollFd::new(xcb_fd, PollFlags::POLLIN)];
 
+            // Check for any events in the internal buffers
+            // before going to sleep:
+            self.drain_xcb_events(handler);
+
             // FIXME: handle errors
             poll(&mut fds, until_next_frame.subsec_millis() as i32).unwrap();
 

--- a/src/x11/xcb_connection.rs
+++ b/src/x11/xcb_connection.rs
@@ -46,6 +46,8 @@ impl XcbConnection {
     pub fn new() -> Result<Self, xcb::base::ConnError> {
         let (conn, xlib_display) = xcb::Connection::connect_with_xlib_display()?;
 
+        conn.set_event_queue_owner(xcb::base::EventQueueOwner::Xcb);
+
         let (wm_protocols, wm_delete_window, wm_normal_hints) = intern_atoms!(&conn, WM_PROTOCOLS, WM_DELETE_WINDOW, WM_NORMAL_HINTS);
 
         Ok(Self {


### PR DESCRIPTION
I went to #xcb on Freenode and psychon was so kind to point me to:
https://docs.rs/x11rb/0.8.0/x11rb/event_loop_integration/index.html

It seems that while events are being handled new events can be queued up
in the internal buffers. And so the next poll() will wait even though there are
still events to be handled.

This is a race condition, so that might be why this does only occur on some systems.