### PR TITLE
tweak x11 frame interval

### DIFF
--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -192,8 +192,7 @@ impl Window {
             window_info,
             mouse_cursor: MouseCursor::default(),
 
-            //frame_interval: Duration::from_millis(15),
-            frame_interval: Duration::from_secs_f64(1.0/70.0),
+            frame_interval: Duration::from_millis(14),
             event_loop_running: false,
 
             new_physical_size: None,

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -192,7 +192,8 @@ impl Window {
             window_info,
             mouse_cursor: MouseCursor::default(),
 
-            frame_interval: Duration::from_millis(15),
+            //frame_interval: Duration::from_millis(15),
+            frame_interval: Duration::from_secs_f64(1.0/70.0),
             event_loop_running: false,
 
             new_physical_size: None,


### PR DESCRIPTION
After tweaking the frame interval in X11, I found 14ms feels smoother than using 15ms, especially when using OpenGL.