### PR TITLE
Merge raw-gl-context into baseview to allow OpenGL contexts to be created during window creation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,9 @@ jobs:
       with:
         toolchain: stable
         override: true
-    - name: Build
+    - name: Build with default features
       run: cargo build --examples --workspace --verbose
+    - name: Build again with all features
+      run: cargo build --examples --workspace --all-features --verbose
     - name: Run tests
-      run: cargo test --examples --workspace --verbose
+      run: cargo test --examples --workspace --all-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ authors = [
 edition = "2018"
 license = "MIT OR Apache-2.0"
 
+[features]
+default = ["opengl"]
+opengl = ["uuid"]
+
 [dependencies]
 keyboard-types = { version = "0.6.1", default-features = false }
 raw-window-handle = "0.4.2"
@@ -26,6 +30,7 @@ nix = "0.22.0"
 
 [target.'cfg(target_os="windows")'.dependencies]
 winapi = { version = "0.3.8", features = ["libloaderapi", "winuser", "windef", "minwindef", "guiddef", "combaseapi", "wingdi", "errhandlingapi"] }
+uuid = { version = "0.8", features = ["v4"], optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
 cocoa = "0.24.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,14 @@ authors = [
     "Billy Messenger <billydm@protonmail.com>",
     "Anton Lazarev <https://antonok.com>",
     "Joakim Frostegård <joakim.frostegard@gmail.com>",
+    "Robbert van der Helm <mail@robbertvanderhelm.nl>",
 ]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 keyboard-types = { version = "0.6.1", default-features = false }
-raw-window-handle = "0.3.3"
+raw-window-handle = "0.4.2"
 
 [target.'cfg(target_os="linux")'.dependencies]
 xcb = { version = "0.9", features = ["thread", "xlib_xcb", "dri2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [features]
-default = ["opengl"]
+default = []
 opengl = ["uuid"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = []
-opengl = ["uuid"]
+opengl = ["uuid", "x11/glx"]
 
 [dependencies]
 keyboard-types = { version = "0.6.1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ Interested in learning more about the project? Join us on [discord](https://disc
 
 Below is a proposed list of milestones (roughly in-order) and their status. Subject to change at any time.
 
-| Feature                                         | Windows            | Mac OS             | Linux              |
-| ----------------------------------------------- | ------------------ | ------------------ | ------------------ |
-| Spawns a window, no parent                      | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Cross-platform API for window spawning          | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Can find DPI scale factor                       |                    | :heavy_check_mark: | :heavy_check_mark: |
-| Basic event handling (mouse, keyboard)          | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Parent window support                           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Feature                                               | Windows            | Mac OS             | Linux              |
+| ----------------------------------------------------- | ------------------ | ------------------ | ------------------ |
+| Spawns a window, no parent                            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Cross-platform API for window spawning                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Can find DPI scale factor                             |                    | :heavy_check_mark: | :heavy_check_mark: |
+| Basic event handling (mouse, keyboard)                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Parent window support                                 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| OpenGL context creation (behind the `opengl` feature) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 
 ## Prerequisites
 

--- a/examples/open_window.rs
+++ b/examples/open_window.rs
@@ -36,6 +36,10 @@ fn main() {
         title: "baseview".into(),
         size: baseview::Size::new(512.0, 512.0),
         scale: WindowScalePolicy::SystemScaleFactor,
+
+        // TODO: Add an example that uses the OpenGL context
+        #[cfg(feature = "opengl")]
+        gl_config: None,
     };
 
     let (mut tx, rx) = RingBuffer::new(128);

--- a/src/gl/lib.rs
+++ b/src/gl/lib.rs
@@ -1,0 +1,100 @@
+use raw_window_handle::HasRawWindowHandle;
+
+use std::ffi::c_void;
+use std::marker::PhantomData;
+
+#[cfg(target_os = "windows")]
+mod win;
+#[cfg(target_os = "windows")]
+use win as platform;
+
+#[cfg(target_os = "linux")]
+mod x11;
+#[cfg(target_os = "linux")]
+use crate::x11 as platform;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+use macos as platform;
+
+#[derive(Clone, Debug)]
+pub struct GlConfig {
+    pub version: (u8, u8),
+    pub profile: Profile,
+    pub red_bits: u8,
+    pub blue_bits: u8,
+    pub green_bits: u8,
+    pub alpha_bits: u8,
+    pub depth_bits: u8,
+    pub stencil_bits: u8,
+    pub samples: Option<u8>,
+    pub srgb: bool,
+    pub double_buffer: bool,
+    pub vsync: bool,
+}
+
+impl Default for GlConfig {
+    fn default() -> Self {
+        GlConfig {
+            version: (3, 2),
+            profile: Profile::Core,
+            red_bits: 8,
+            blue_bits: 8,
+            green_bits: 8,
+            alpha_bits: 8,
+            depth_bits: 24,
+            stencil_bits: 8,
+            samples: None,
+            srgb: true,
+            double_buffer: true,
+            vsync: false,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Profile {
+    Compatibility,
+    Core,
+}
+
+#[derive(Debug)]
+pub enum GlError {
+    InvalidWindowHandle,
+    VersionNotSupported,
+    CreationFailed(platform::CreationFailedError),
+}
+
+pub struct GlContext {
+    context: platform::GlContext,
+    phantom: PhantomData<*mut ()>,
+}
+
+impl GlContext {
+    pub unsafe fn create(
+        parent: &impl HasRawWindowHandle,
+        config: GlConfig,
+    ) -> Result<GlContext, GlError> {
+        platform::GlContext::create(parent, config).map(|context| GlContext {
+            context,
+            phantom: PhantomData,
+        })
+    }
+
+    pub unsafe fn make_current(&self) {
+        self.context.make_current();
+    }
+
+    pub unsafe fn make_not_current(&self) {
+        self.context.make_not_current();
+    }
+
+    pub fn get_proc_address(&self, symbol: &str) -> *const c_void {
+        self.context.get_proc_address(symbol)
+    }
+
+    pub fn swap_buffers(&self) {
+        self.context.swap_buffers();
+    }
+}

--- a/src/gl/macos.rs
+++ b/src/gl/macos.rs
@@ -1,0 +1,147 @@
+use std::ffi::c_void;
+use std::str::FromStr;
+
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+
+use cocoa::appkit::{
+    NSOpenGLContext, NSOpenGLContextParameter, NSOpenGLPFAAccelerated, NSOpenGLPFAAlphaSize,
+    NSOpenGLPFAColorSize, NSOpenGLPFADepthSize, NSOpenGLPFADoubleBuffer, NSOpenGLPFAMultisample,
+    NSOpenGLPFAOpenGLProfile, NSOpenGLPFASampleBuffers, NSOpenGLPFASamples, NSOpenGLPFAStencilSize,
+    NSOpenGLPixelFormat, NSOpenGLProfileVersion3_2Core, NSOpenGLProfileVersion4_1Core,
+    NSOpenGLProfileVersionLegacy, NSOpenGLView, NSView,
+};
+use cocoa::base::{id, nil, YES};
+
+use core_foundation::base::TCFType;
+use core_foundation::bundle::{CFBundleGetBundleWithIdentifier, CFBundleGetFunctionPointerForName};
+use core_foundation::string::CFString;
+
+use objc::{msg_send, sel, sel_impl};
+
+use crate::{GlConfig, GlError, Profile};
+
+pub type CreationFailedError = ();
+pub struct GlContext {
+    view: id,
+    context: id,
+}
+
+impl GlContext {
+    pub unsafe fn create(
+        parent: &impl HasRawWindowHandle,
+        config: GlConfig,
+    ) -> Result<GlContext, GlError> {
+        let handle = if let RawWindowHandle::MacOS(handle) = parent.raw_window_handle() {
+            handle
+        } else {
+            return Err(GlError::InvalidWindowHandle);
+        };
+
+        if handle.ns_view.is_null() {
+            return Err(GlError::InvalidWindowHandle);
+        }
+
+        let parent_view = handle.ns_view as id;
+
+        let version = if config.version < (3, 2) && config.profile == Profile::Compatibility {
+            NSOpenGLProfileVersionLegacy
+        } else if config.version == (3, 2) && config.profile == Profile::Core {
+            NSOpenGLProfileVersion3_2Core
+        } else if config.version > (3, 2) && config.profile == Profile::Core {
+            NSOpenGLProfileVersion4_1Core
+        } else {
+            return Err(GlError::VersionNotSupported);
+        };
+
+        #[rustfmt::skip]
+        let mut attrs = vec![
+            NSOpenGLPFAOpenGLProfile as u32, version as u32,
+            NSOpenGLPFAColorSize as u32, (config.red_bits + config.blue_bits + config.green_bits) as u32,
+            NSOpenGLPFAAlphaSize as u32, config.alpha_bits as u32,
+            NSOpenGLPFADepthSize as u32, config.depth_bits as u32,
+            NSOpenGLPFAStencilSize as u32, config.stencil_bits as u32,
+            NSOpenGLPFAAccelerated as u32,
+        ];
+
+        if config.samples.is_some() {
+            #[rustfmt::skip]
+            attrs.extend_from_slice(&[
+                NSOpenGLPFAMultisample as u32,
+                NSOpenGLPFASampleBuffers as u32, 1,
+                NSOpenGLPFASamples as u32, config.samples.unwrap() as u32,
+            ]);
+        }
+
+        if config.double_buffer {
+            attrs.push(NSOpenGLPFADoubleBuffer as u32);
+        }
+
+        attrs.push(0);
+
+        let pixel_format = NSOpenGLPixelFormat::alloc(nil).initWithAttributes_(&attrs);
+
+        if pixel_format == nil {
+            return Err(GlError::CreationFailed(()));
+        }
+
+        let view =
+            NSOpenGLView::alloc(nil).initWithFrame_pixelFormat_(parent_view.frame(), pixel_format);
+
+        if view == nil {
+            return Err(GlError::CreationFailed(()));
+        }
+
+        view.setWantsBestResolutionOpenGLSurface_(YES);
+
+        let () = msg_send![view, retain];
+        NSOpenGLView::display_(view);
+        parent_view.addSubview_(view);
+
+        let context: id = msg_send![view, openGLContext];
+        let () = msg_send![context, retain];
+
+        context.setValues_forParameter_(
+            &(config.vsync as i32),
+            NSOpenGLContextParameter::NSOpenGLCPSwapInterval,
+        );
+
+        let () = msg_send![pixel_format, release];
+
+        Ok(GlContext { view, context })
+    }
+
+    pub unsafe fn make_current(&self) {
+        self.context.makeCurrentContext();
+    }
+
+    pub unsafe fn make_not_current(&self) {
+        NSOpenGLContext::clearCurrentContext(self.context);
+    }
+
+    pub fn get_proc_address(&self, symbol: &str) -> *const c_void {
+        let symbol_name = CFString::from_str(symbol).unwrap();
+        let framework_name = CFString::from_str("com.apple.opengl").unwrap();
+        let framework =
+            unsafe { CFBundleGetBundleWithIdentifier(framework_name.as_concrete_TypeRef()) };
+        let addr = unsafe {
+            CFBundleGetFunctionPointerForName(framework, symbol_name.as_concrete_TypeRef())
+        };
+        addr as *const c_void
+    }
+
+    pub fn swap_buffers(&self) {
+        unsafe {
+            self.context.flushBuffer();
+            let () = msg_send![self.view, setNeedsDisplay: YES];
+        }
+    }
+}
+
+impl Drop for GlContext {
+    fn drop(&mut self) {
+        unsafe {
+            let () = msg_send![self.context, release];
+            let () = msg_send![self.view, release];
+        }
+    }
+}

--- a/src/gl/macos.rs
+++ b/src/gl/macos.rs
@@ -18,7 +18,7 @@ use core_foundation::string::CFString;
 
 use objc::{msg_send, sel, sel_impl};
 
-use crate::{GlConfig, GlError, Profile};
+use super::{GlConfig, GlError, Profile};
 
 pub type CreationFailedError = ();
 pub struct GlContext {
@@ -28,10 +28,9 @@ pub struct GlContext {
 
 impl GlContext {
     pub unsafe fn create(
-        parent: &impl HasRawWindowHandle,
-        config: GlConfig,
+        parent: &impl HasRawWindowHandle, config: GlConfig,
     ) -> Result<GlContext, GlError> {
-        let handle = if let RawWindowHandle::MacOS(handle) = parent.raw_window_handle() {
+        let handle = if let RawWindowHandle::AppKit(handle) = parent.raw_window_handle() {
             handle
         } else {
             return Err(GlError::InvalidWindowHandle);

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -11,7 +11,7 @@ use win as platform;
 #[cfg(target_os = "linux")]
 mod x11;
 #[cfg(target_os = "linux")]
-use crate::x11 as platform;
+use self::x11 as platform;
 
 #[cfg(target_os = "macos")]
 mod macos;
@@ -73,13 +73,10 @@ pub struct GlContext {
 
 impl GlContext {
     pub unsafe fn create(
-        parent: &impl HasRawWindowHandle,
-        config: GlConfig,
+        parent: &impl HasRawWindowHandle, config: GlConfig,
     ) -> Result<GlContext, GlError> {
-        platform::GlContext::create(parent, config).map(|context| GlContext {
-            context,
-            phantom: PhantomData,
-        })
+        platform::GlContext::create(parent, config)
+            .map(|context| GlContext { context, phantom: PhantomData })
     }
 
     pub unsafe fn make_current(&self) {

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -72,7 +72,7 @@ pub struct GlContext {
 }
 
 impl GlContext {
-    pub unsafe fn create(
+    pub(crate) unsafe fn create(
         parent: &impl HasRawWindowHandle, config: GlConfig,
     ) -> Result<GlContext, GlError> {
         platform::GlContext::create(parent, config)

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -1,7 +1,9 @@
-use raw_window_handle::HasRawWindowHandle;
-
 use std::ffi::c_void;
 use std::marker::PhantomData;
+
+// On X11 creating the context is a two step process
+#[cfg(not(target_os = "linux"))]
+use raw_window_handle::HasRawWindowHandle;
 
 #[cfg(target_os = "windows")]
 mod win;

--- a/src/gl/win.rs
+++ b/src/gl/win.rs
@@ -1,0 +1,312 @@
+use std::ffi::{c_void, CString, OsStr};
+use std::os::windows::ffi::OsStrExt;
+
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+
+use winapi::shared::minwindef::{HINSTANCE, HMODULE};
+use winapi::shared::ntdef::WCHAR;
+use winapi::shared::windef::{HDC, HGLRC, HWND};
+use winapi::um::libloaderapi::{FreeLibrary, GetProcAddress, LoadLibraryA};
+use winapi::um::wingdi::{
+    wglCreateContext, wglDeleteContext, wglGetProcAddress, wglMakeCurrent, ChoosePixelFormat,
+    DescribePixelFormat, SetPixelFormat, SwapBuffers, PFD_DOUBLEBUFFER, PFD_DRAW_TO_WINDOW,
+    PFD_MAIN_PLANE, PFD_SUPPORT_OPENGL, PFD_TYPE_RGBA, PIXELFORMATDESCRIPTOR,
+};
+use winapi::um::winnt::IMAGE_DOS_HEADER;
+use winapi::um::winuser::{
+    CreateWindowExW, DefWindowProcW, DestroyWindow, GetDC, RegisterClassW, ReleaseDC,
+    UnregisterClassW, CS_OWNDC, CW_USEDEFAULT, WNDCLASSW,
+};
+
+use crate::{GlConfig, GlError, Profile};
+
+// See https://www.khronos.org/registry/OpenGL/extensions/ARB/WGL_ARB_create_context.txt
+
+type WglCreateContextAttribsARB = extern "system" fn(HDC, HGLRC, *const i32) -> HGLRC;
+
+const WGL_CONTEXT_MAJOR_VERSION_ARB: i32 = 0x2091;
+const WGL_CONTEXT_MINOR_VERSION_ARB: i32 = 0x2092;
+const WGL_CONTEXT_PROFILE_MASK_ARB: i32 = 0x9126;
+
+const WGL_CONTEXT_CORE_PROFILE_BIT_ARB: i32 = 0x00000001;
+const WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB: i32 = 0x00000002;
+
+// See https://www.khronos.org/registry/OpenGL/extensions/ARB/WGL_ARB_pixel_format.txt
+
+type WglChoosePixelFormatARB =
+    extern "system" fn(HDC, *const i32, *const f32, u32, *mut i32, *mut u32) -> i32;
+
+const WGL_DRAW_TO_WINDOW_ARB: i32 = 0x2001;
+const WGL_ACCELERATION_ARB: i32 = 0x2003;
+const WGL_SUPPORT_OPENGL_ARB: i32 = 0x2010;
+const WGL_DOUBLE_BUFFER_ARB: i32 = 0x2011;
+const WGL_PIXEL_TYPE_ARB: i32 = 0x2013;
+const WGL_RED_BITS_ARB: i32 = 0x2015;
+const WGL_GREEN_BITS_ARB: i32 = 0x2017;
+const WGL_BLUE_BITS_ARB: i32 = 0x2019;
+const WGL_ALPHA_BITS_ARB: i32 = 0x201B;
+const WGL_DEPTH_BITS_ARB: i32 = 0x2022;
+const WGL_STENCIL_BITS_ARB: i32 = 0x2023;
+
+const WGL_FULL_ACCELERATION_ARB: i32 = 0x2027;
+const WGL_TYPE_RGBA_ARB: i32 = 0x202B;
+
+// See https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_multisample.txt
+
+const WGL_SAMPLE_BUFFERS_ARB: i32 = 0x2041;
+const WGL_SAMPLES_ARB: i32 = 0x2042;
+
+// See https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_framebuffer_sRGB.txt
+
+const WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB: i32 = 0x20A9;
+
+// See https://www.khronos.org/registry/OpenGL/extensions/EXT/WGL_EXT_swap_control.txt
+
+type WglSwapIntervalEXT = extern "system" fn(i32) -> i32;
+
+pub type CreationFailedError = ();
+pub struct GlContext {
+    hwnd: HWND,
+    hdc: HDC,
+    hglrc: HGLRC,
+    gl_library: HMODULE,
+}
+
+extern "C" {
+    static __ImageBase: IMAGE_DOS_HEADER;
+}
+
+impl GlContext {
+    pub unsafe fn create(
+        parent: &impl HasRawWindowHandle,
+        config: GlConfig,
+    ) -> Result<GlContext, GlError> {
+        let handle = if let RawWindowHandle::Windows(handle) = parent.raw_window_handle() {
+            handle
+        } else {
+            return Err(GlError::InvalidWindowHandle);
+        };
+
+        if handle.hwnd.is_null() {
+            return Err(GlError::InvalidWindowHandle);
+        }
+
+        // Create temporary window and context to load function pointers
+
+        let class_name_str = format!("raw-gl-context-window-{}", uuid::Uuid::new_v4().to_simple());
+        let mut class_name: Vec<WCHAR> = OsStr::new(&class_name_str).encode_wide().collect();
+        class_name.push(0);
+
+        let hinstance = &__ImageBase as *const IMAGE_DOS_HEADER as HINSTANCE;
+
+        let wnd_class = WNDCLASSW {
+            style: CS_OWNDC,
+            lpfnWndProc: Some(DefWindowProcW),
+            hInstance: hinstance,
+            lpszClassName: class_name.as_ptr(),
+            ..std::mem::zeroed()
+        };
+
+        let class = RegisterClassW(&wnd_class);
+        if class == 0 {
+            return Err(GlError::CreationFailed(()));
+        }
+
+        let hwnd_tmp = CreateWindowExW(
+            0,
+            class as *const WCHAR,
+            [0].as_ptr(),
+            0,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            hinstance,
+            std::ptr::null_mut(),
+        );
+
+        if hwnd_tmp.is_null() {
+            return Err(GlError::CreationFailed(()));
+        }
+
+        let hdc_tmp = GetDC(hwnd_tmp);
+
+        let pfd_tmp = PIXELFORMATDESCRIPTOR {
+            nSize: std::mem::size_of::<PIXELFORMATDESCRIPTOR>() as u16,
+            nVersion: 1,
+            dwFlags: PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
+            iPixelType: PFD_TYPE_RGBA,
+            cColorBits: 32,
+            cAlphaBits: 8,
+            cDepthBits: 24,
+            cStencilBits: 8,
+            iLayerType: PFD_MAIN_PLANE,
+            ..std::mem::zeroed()
+        };
+
+        SetPixelFormat(hdc_tmp, ChoosePixelFormat(hdc_tmp, &pfd_tmp), &pfd_tmp);
+
+        let hglrc_tmp = wglCreateContext(hdc_tmp);
+        if hglrc_tmp.is_null() {
+            ReleaseDC(hwnd_tmp, hdc_tmp);
+            UnregisterClassW(class as *const WCHAR, hinstance);
+            DestroyWindow(hwnd_tmp);
+            return Err(GlError::CreationFailed(()));
+        }
+
+        wglMakeCurrent(hdc_tmp, hglrc_tmp);
+
+        #[allow(non_snake_case)]
+        let wglCreateContextAttribsARB: Option<WglCreateContextAttribsARB> = {
+            let symbol = CString::new("wglCreateContextAttribsARB").unwrap();
+            let addr = wglGetProcAddress(symbol.as_ptr());
+            if !addr.is_null() {
+                Some(std::mem::transmute(addr))
+            } else {
+                None
+            }
+        };
+
+        #[allow(non_snake_case)]
+        let wglChoosePixelFormatARB: Option<WglChoosePixelFormatARB> = {
+            let symbol = CString::new("wglChoosePixelFormatARB").unwrap();
+            let addr = wglGetProcAddress(symbol.as_ptr());
+            if !addr.is_null() {
+                Some(std::mem::transmute(addr))
+            } else {
+                None
+            }
+        };
+
+        #[allow(non_snake_case)]
+        let wglSwapIntervalEXT: Option<WglSwapIntervalEXT> = {
+            let symbol = CString::new("wglSwapIntervalEXT").unwrap();
+            let addr = wglGetProcAddress(symbol.as_ptr());
+            if !addr.is_null() {
+                Some(std::mem::transmute(addr))
+            } else {
+                None
+            }
+        };
+
+        wglMakeCurrent(hdc_tmp, std::ptr::null_mut());
+        ReleaseDC(hwnd_tmp, hdc_tmp);
+        UnregisterClassW(class as *const WCHAR, hinstance);
+        DestroyWindow(hwnd_tmp);
+
+        // Create actual context
+
+        let hwnd = handle.hwnd as HWND;
+
+        let hdc = GetDC(hwnd);
+
+        #[rustfmt::skip]
+        let pixel_format_attribs = [
+            WGL_DRAW_TO_WINDOW_ARB, 1,
+            WGL_ACCELERATION_ARB, WGL_FULL_ACCELERATION_ARB,
+            WGL_SUPPORT_OPENGL_ARB, 1,
+            WGL_DOUBLE_BUFFER_ARB, config.double_buffer as i32,
+            WGL_PIXEL_TYPE_ARB, WGL_TYPE_RGBA_ARB,
+            WGL_RED_BITS_ARB, config.red_bits as i32,
+            WGL_GREEN_BITS_ARB, config.green_bits as i32,
+            WGL_BLUE_BITS_ARB, config.blue_bits as i32,
+            WGL_ALPHA_BITS_ARB, config.alpha_bits as i32,
+            WGL_DEPTH_BITS_ARB, config.depth_bits as i32,
+            WGL_STENCIL_BITS_ARB, config.stencil_bits as i32,
+            WGL_SAMPLE_BUFFERS_ARB, config.samples.is_some() as i32,
+            WGL_SAMPLES_ARB, config.samples.unwrap_or(0) as i32,
+            WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB, config.srgb as i32,
+            0,
+        ];
+
+        let mut pixel_format = 0;
+        let mut num_formats = 0;
+        wglChoosePixelFormatARB.unwrap()(
+            hdc,
+            pixel_format_attribs.as_ptr(),
+            std::ptr::null(),
+            1,
+            &mut pixel_format,
+            &mut num_formats,
+        );
+
+        let mut pfd: PIXELFORMATDESCRIPTOR = std::mem::zeroed();
+        DescribePixelFormat(
+            hdc,
+            pixel_format,
+            std::mem::size_of::<PIXELFORMATDESCRIPTOR>() as u32,
+            &mut pfd,
+        );
+        SetPixelFormat(hdc, pixel_format, &pfd);
+
+        let profile_mask = match config.profile {
+            Profile::Core => WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
+            Profile::Compatibility => WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+        };
+
+        #[rustfmt::skip]
+        let ctx_attribs = [
+            WGL_CONTEXT_MAJOR_VERSION_ARB, config.version.0 as i32,
+            WGL_CONTEXT_MINOR_VERSION_ARB, config.version.1 as i32,
+            WGL_CONTEXT_PROFILE_MASK_ARB, profile_mask,
+            0
+        ];
+
+        let hglrc =
+            wglCreateContextAttribsARB.unwrap()(hdc, std::ptr::null_mut(), ctx_attribs.as_ptr());
+        if hglrc == std::ptr::null_mut() {
+            return Err(GlError::CreationFailed(()));
+        }
+
+        let gl_library_name = CString::new("opengl32.dll").unwrap();
+        let gl_library = LoadLibraryA(gl_library_name.as_ptr());
+
+        wglMakeCurrent(hdc, hglrc);
+        wglSwapIntervalEXT.unwrap()(config.vsync as i32);
+        wglMakeCurrent(hdc, std::ptr::null_mut());
+
+        Ok(GlContext {
+            hwnd,
+            hdc,
+            hglrc,
+            gl_library,
+        })
+    }
+
+    pub unsafe fn make_current(&self) {
+        wglMakeCurrent(self.hdc, self.hglrc);
+    }
+
+    pub unsafe fn make_not_current(&self) {
+        wglMakeCurrent(self.hdc, std::ptr::null_mut());
+    }
+
+    pub fn get_proc_address(&self, symbol: &str) -> *const c_void {
+        let symbol = CString::new(symbol).unwrap();
+        let addr = unsafe { wglGetProcAddress(symbol.as_ptr()) as *const c_void };
+        if !addr.is_null() {
+            addr
+        } else {
+            unsafe { GetProcAddress(self.gl_library, symbol.as_ptr()) as *const c_void }
+        }
+    }
+
+    pub fn swap_buffers(&self) {
+        unsafe {
+            SwapBuffers(self.hdc);
+        }
+    }
+}
+
+impl Drop for GlContext {
+    fn drop(&mut self) {
+        unsafe {
+            wglMakeCurrent(std::ptr::null_mut(), std::ptr::null_mut());
+            wglDeleteContext(self.hglrc);
+            ReleaseDC(self.hwnd, self.hdc);
+            FreeLibrary(self.gl_library);
+        }
+    }
+}

--- a/src/gl/win.rs
+++ b/src/gl/win.rs
@@ -255,7 +255,7 @@ impl GlContext {
 
         let hglrc =
             wglCreateContextAttribsARB.unwrap()(hdc, std::ptr::null_mut(), ctx_attribs.as_ptr());
-        if hglrc == std::ptr::null_mut() {
+        if hglrc.is_null() {
             return Err(GlError::CreationFailed(()));
         }
 

--- a/src/gl/win.rs
+++ b/src/gl/win.rs
@@ -18,7 +18,7 @@ use winapi::um::winuser::{
     UnregisterClassW, CS_OWNDC, CW_USEDEFAULT, WNDCLASSW,
 };
 
-use crate::{GlConfig, GlError, Profile};
+use super::{GlConfig, GlError, Profile};
 
 // See https://www.khronos.org/registry/OpenGL/extensions/ARB/WGL_ARB_create_context.txt
 
@@ -78,10 +78,9 @@ extern "C" {
 
 impl GlContext {
     pub unsafe fn create(
-        parent: &impl HasRawWindowHandle,
-        config: GlConfig,
+        parent: &impl HasRawWindowHandle, config: GlConfig,
     ) -> Result<GlContext, GlError> {
-        let handle = if let RawWindowHandle::Windows(handle) = parent.raw_window_handle() {
+        let handle = if let RawWindowHandle::Win32(handle) = parent.raw_window_handle() {
             handle
         } else {
             return Err(GlError::InvalidWindowHandle);
@@ -267,12 +266,7 @@ impl GlContext {
         wglSwapIntervalEXT.unwrap()(config.vsync as i32);
         wglMakeCurrent(hdc, std::ptr::null_mut());
 
-        Ok(GlContext {
-            hwnd,
-            hdc,
-            hglrc,
-            gl_library,
-        })
+        Ok(GlContext { hwnd, hdc, hglrc, gl_library })
     }
 
     pub unsafe fn make_current(&self) {

--- a/src/gl/x11.rs
+++ b/src/gl/x11.rs
@@ -6,7 +6,7 @@ use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 use x11::glx;
 use x11::xlib;
 
-use crate::{GlConfig, GlError, Profile};
+use super::{GlConfig, GlError, Profile};
 
 mod errors;
 
@@ -57,8 +57,7 @@ pub struct GlContext {
 
 impl GlContext {
     pub unsafe fn create(
-        parent: &impl HasRawWindowHandle,
-        config: GlConfig,
+        parent: &impl HasRawWindowHandle, config: GlConfig,
     ) -> Result<GlContext, GlError> {
         let handle = if let RawWindowHandle::Xlib(handle) = parent.raw_window_handle() {
             handle
@@ -102,18 +101,14 @@ impl GlContext {
             error_handler.check()?;
 
             if n_configs <= 0 {
-                return Err(GlError::CreationFailed(
-                    CreationFailedError::InvalidFBConfig,
-                ));
+                return Err(GlError::CreationFailed(CreationFailedError::InvalidFBConfig));
             }
 
             #[allow(non_snake_case)]
             let glXCreateContextAttribsARB: GlXCreateContextAttribsARB = unsafe {
                 let addr = get_proc_address("glXCreateContextAttribsARB");
                 if addr.is_null() {
-                    return Err(GlError::CreationFailed(
-                        CreationFailedError::GetProcAddressFailed,
-                    ));
+                    return Err(GlError::CreationFailed(CreationFailedError::GetProcAddressFailed));
                 } else {
                     std::mem::transmute(addr)
                 }
@@ -123,9 +118,7 @@ impl GlContext {
             let glXSwapIntervalEXT: GlXSwapIntervalEXT = unsafe {
                 let addr = get_proc_address("glXSwapIntervalEXT");
                 if addr.is_null() {
-                    return Err(GlError::CreationFailed(
-                        CreationFailedError::GetProcAddressFailed,
-                    ));
+                    return Err(GlError::CreationFailed(CreationFailedError::GetProcAddressFailed));
                 } else {
                     std::mem::transmute(addr)
                 }
@@ -159,18 +152,14 @@ impl GlContext {
             error_handler.check()?;
 
             if context.is_null() {
-                return Err(GlError::CreationFailed(
-                    CreationFailedError::ContextCreationFailed,
-                ));
+                return Err(GlError::CreationFailed(CreationFailedError::ContextCreationFailed));
             }
 
             unsafe {
                 let res = glx::glXMakeCurrent(display, handle.window, context);
                 error_handler.check()?;
                 if res == 0 {
-                    return Err(GlError::CreationFailed(
-                        CreationFailedError::MakeCurrentFailed,
-                    ));
+                    return Err(GlError::CreationFailed(CreationFailedError::MakeCurrentFailed));
                 }
 
                 glXSwapIntervalEXT(display, handle.window, config.vsync as i32);
@@ -178,17 +167,11 @@ impl GlContext {
 
                 if glx::glXMakeCurrent(display, 0, std::ptr::null_mut()) == 0 {
                     error_handler.check()?;
-                    return Err(GlError::CreationFailed(
-                        CreationFailedError::MakeCurrentFailed,
-                    ));
+                    return Err(GlError::CreationFailed(CreationFailedError::MakeCurrentFailed));
                 }
             }
 
-            Ok(GlContext {
-                window: handle.window,
-                display,
-                context,
-            })
+            Ok(GlContext { window: handle.window, display, context })
         })
     }
 

--- a/src/gl/x11.rs
+++ b/src/gl/x11.rs
@@ -1,0 +1,231 @@
+use std::ffi::{c_void, CString};
+use std::os::raw::{c_int, c_ulong};
+
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+
+use x11::glx;
+use x11::xlib;
+
+use crate::{GlConfig, GlError, Profile};
+
+mod errors;
+
+#[derive(Debug)]
+pub enum CreationFailedError {
+    InvalidFBConfig,
+    GetProcAddressFailed,
+    MakeCurrentFailed,
+    ContextCreationFailed,
+    X11Error(errors::XLibError),
+}
+
+impl From<errors::XLibError> for GlError {
+    fn from(e: errors::XLibError) -> Self {
+        GlError::CreationFailed(CreationFailedError::X11Error(e))
+    }
+}
+
+// See https://www.khronos.org/registry/OpenGL/extensions/ARB/GLX_ARB_create_context.txt
+
+type GlXCreateContextAttribsARB = unsafe extern "C" fn(
+    dpy: *mut xlib::Display,
+    fbc: glx::GLXFBConfig,
+    share_context: glx::GLXContext,
+    direct: xlib::Bool,
+    attribs: *const c_int,
+) -> glx::GLXContext;
+
+// See https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_swap_control.txt
+
+type GlXSwapIntervalEXT =
+    unsafe extern "C" fn(dpy: *mut xlib::Display, drawable: glx::GLXDrawable, interval: i32);
+
+// See https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_framebuffer_sRGB.txt
+
+const GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB: i32 = 0x20B2;
+
+fn get_proc_address(symbol: &str) -> *const c_void {
+    let symbol = CString::new(symbol).unwrap();
+    unsafe { glx::glXGetProcAddress(symbol.as_ptr() as *const u8).unwrap() as *const c_void }
+}
+
+pub struct GlContext {
+    window: c_ulong,
+    display: *mut xlib::_XDisplay,
+    context: glx::GLXContext,
+}
+
+impl GlContext {
+    pub unsafe fn create(
+        parent: &impl HasRawWindowHandle,
+        config: GlConfig,
+    ) -> Result<GlContext, GlError> {
+        let handle = if let RawWindowHandle::Xlib(handle) = parent.raw_window_handle() {
+            handle
+        } else {
+            return Err(GlError::InvalidWindowHandle);
+        };
+
+        if handle.display.is_null() {
+            return Err(GlError::InvalidWindowHandle);
+        }
+
+        let display = handle.display as *mut xlib::_XDisplay;
+
+        errors::XErrorHandler::handle(display, |error_handler| {
+            let screen = unsafe { xlib::XDefaultScreen(display) };
+
+            #[rustfmt::skip]
+                let fb_attribs = [
+                glx::GLX_X_RENDERABLE, 1,
+                glx::GLX_X_VISUAL_TYPE, glx::GLX_TRUE_COLOR,
+                glx::GLX_DRAWABLE_TYPE, glx::GLX_WINDOW_BIT,
+                glx::GLX_RENDER_TYPE, glx::GLX_RGBA_BIT,
+                glx::GLX_RED_SIZE, config.red_bits as i32,
+                glx::GLX_GREEN_SIZE, config.green_bits as i32,
+                glx::GLX_BLUE_SIZE, config.blue_bits as i32,
+                glx::GLX_ALPHA_SIZE, config.alpha_bits as i32,
+                glx::GLX_DEPTH_SIZE, config.depth_bits as i32,
+                glx::GLX_STENCIL_SIZE, config.stencil_bits as i32,
+                glx::GLX_DOUBLEBUFFER, config.double_buffer as i32,
+                glx::GLX_SAMPLE_BUFFERS, config.samples.is_some() as i32,
+                glx::GLX_SAMPLES, config.samples.unwrap_or(0) as i32,
+                GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB, config.srgb as i32,
+                0,
+            ];
+
+            let mut n_configs = 0;
+            let fb_config = unsafe {
+                glx::glXChooseFBConfig(display, screen, fb_attribs.as_ptr(), &mut n_configs)
+            };
+
+            error_handler.check()?;
+
+            if n_configs <= 0 {
+                return Err(GlError::CreationFailed(
+                    CreationFailedError::InvalidFBConfig,
+                ));
+            }
+
+            #[allow(non_snake_case)]
+            let glXCreateContextAttribsARB: GlXCreateContextAttribsARB = unsafe {
+                let addr = get_proc_address("glXCreateContextAttribsARB");
+                if addr.is_null() {
+                    return Err(GlError::CreationFailed(
+                        CreationFailedError::GetProcAddressFailed,
+                    ));
+                } else {
+                    std::mem::transmute(addr)
+                }
+            };
+
+            #[allow(non_snake_case)]
+            let glXSwapIntervalEXT: GlXSwapIntervalEXT = unsafe {
+                let addr = get_proc_address("glXSwapIntervalEXT");
+                if addr.is_null() {
+                    return Err(GlError::CreationFailed(
+                        CreationFailedError::GetProcAddressFailed,
+                    ));
+                } else {
+                    std::mem::transmute(addr)
+                }
+            };
+
+            error_handler.check()?;
+
+            let profile_mask = match config.profile {
+                Profile::Core => glx::arb::GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
+                Profile::Compatibility => glx::arb::GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+            };
+
+            #[rustfmt::skip]
+                let ctx_attribs = [
+                glx::arb::GLX_CONTEXT_MAJOR_VERSION_ARB, config.version.0 as i32,
+                glx::arb::GLX_CONTEXT_MINOR_VERSION_ARB, config.version.1 as i32,
+                glx::arb::GLX_CONTEXT_PROFILE_MASK_ARB, profile_mask,
+                0,
+            ];
+
+            let context = unsafe {
+                glXCreateContextAttribsARB(
+                    display,
+                    *fb_config,
+                    std::ptr::null_mut(),
+                    1,
+                    ctx_attribs.as_ptr(),
+                )
+            };
+
+            error_handler.check()?;
+
+            if context.is_null() {
+                return Err(GlError::CreationFailed(
+                    CreationFailedError::ContextCreationFailed,
+                ));
+            }
+
+            unsafe {
+                let res = glx::glXMakeCurrent(display, handle.window, context);
+                error_handler.check()?;
+                if res == 0 {
+                    return Err(GlError::CreationFailed(
+                        CreationFailedError::MakeCurrentFailed,
+                    ));
+                }
+
+                glXSwapIntervalEXT(display, handle.window, config.vsync as i32);
+                error_handler.check()?;
+
+                if glx::glXMakeCurrent(display, 0, std::ptr::null_mut()) == 0 {
+                    error_handler.check()?;
+                    return Err(GlError::CreationFailed(
+                        CreationFailedError::MakeCurrentFailed,
+                    ));
+                }
+            }
+
+            Ok(GlContext {
+                window: handle.window,
+                display,
+                context,
+            })
+        })
+    }
+
+    pub unsafe fn make_current(&self) {
+        errors::XErrorHandler::handle(self.display, |error_handler| {
+            let res = glx::glXMakeCurrent(self.display, self.window, self.context);
+            error_handler.check().unwrap();
+            if res == 0 {
+                panic!("make_current failed")
+            }
+        })
+    }
+
+    pub unsafe fn make_not_current(&self) {
+        errors::XErrorHandler::handle(self.display, |error_handler| {
+            let res = glx::glXMakeCurrent(self.display, 0, std::ptr::null_mut());
+            error_handler.check().unwrap();
+            if res == 0 {
+                panic!("make_not_current failed")
+            }
+        })
+    }
+
+    pub fn get_proc_address(&self, symbol: &str) -> *const c_void {
+        get_proc_address(symbol)
+    }
+
+    pub fn swap_buffers(&self) {
+        errors::XErrorHandler::handle(self.display, |error_handler| {
+            unsafe {
+                glx::glXSwapBuffers(self.display, self.window);
+            }
+            error_handler.check().unwrap();
+        })
+    }
+}
+
+impl Drop for GlContext {
+    fn drop(&mut self) {}
+}

--- a/src/gl/x11.rs
+++ b/src/gl/x11.rs
@@ -96,7 +96,7 @@ impl GlContext {
 
         errors::XErrorHandler::handle(display, |error_handler| {
             #[allow(non_snake_case)]
-            let glXCreateContextAttribsARB: GlXCreateContextAttribsARB = unsafe {
+            let glXCreateContextAttribsARB: GlXCreateContextAttribsARB = {
                 let addr = get_proc_address("glXCreateContextAttribsARB");
                 if addr.is_null() {
                     return Err(GlError::CreationFailed(CreationFailedError::GetProcAddressFailed));
@@ -106,7 +106,7 @@ impl GlContext {
             };
 
             #[allow(non_snake_case)]
-            let glXSwapIntervalEXT: GlXSwapIntervalEXT = unsafe {
+            let glXSwapIntervalEXT: GlXSwapIntervalEXT = {
                 let addr = get_proc_address("glXSwapIntervalEXT");
                 if addr.is_null() {
                     return Err(GlError::CreationFailed(CreationFailedError::GetProcAddressFailed));
@@ -130,15 +130,13 @@ impl GlContext {
                 0,
             ];
 
-            let context = unsafe {
-                glXCreateContextAttribsARB(
-                    display,
-                    config.fb_config,
-                    std::ptr::null_mut(),
-                    1,
-                    ctx_attribs.as_ptr(),
-                )
-            };
+            let context = glXCreateContextAttribsARB(
+                display,
+                config.fb_config,
+                std::ptr::null_mut(),
+                1,
+                ctx_attribs.as_ptr(),
+            );
 
             error_handler.check()?;
 
@@ -146,20 +144,18 @@ impl GlContext {
                 return Err(GlError::CreationFailed(CreationFailedError::ContextCreationFailed));
             }
 
-            unsafe {
-                let res = glx::glXMakeCurrent(display, handle.window, context);
-                error_handler.check()?;
-                if res == 0 {
-                    return Err(GlError::CreationFailed(CreationFailedError::MakeCurrentFailed));
-                }
+            let res = glx::glXMakeCurrent(display, handle.window, context);
+            error_handler.check()?;
+            if res == 0 {
+                return Err(GlError::CreationFailed(CreationFailedError::MakeCurrentFailed));
+            }
 
-                glXSwapIntervalEXT(display, handle.window, config.gl_config.vsync as i32);
-                error_handler.check()?;
+            glXSwapIntervalEXT(display, handle.window, config.gl_config.vsync as i32);
+            error_handler.check()?;
 
-                if glx::glXMakeCurrent(display, 0, std::ptr::null_mut()) == 0 {
-                    error_handler.check()?;
-                    return Err(GlError::CreationFailed(CreationFailedError::MakeCurrentFailed));
-                }
+            if glx::glXMakeCurrent(display, 0, std::ptr::null_mut()) == 0 {
+                error_handler.check()?;
+                return Err(GlError::CreationFailed(CreationFailedError::MakeCurrentFailed));
             }
 
             Ok(GlContext { window: handle.window, display, context })
@@ -173,7 +169,7 @@ impl GlContext {
         display: *mut xlib::_XDisplay, config: GlConfig,
     ) -> Result<(FbConfig, WindowConfig), GlError> {
         errors::XErrorHandler::handle(display, |error_handler| {
-            let screen = unsafe { xlib::XDefaultScreen(display) };
+            let screen = xlib::XDefaultScreen(display);
 
             #[rustfmt::skip]
                 let fb_attribs = [
@@ -195,9 +191,8 @@ impl GlContext {
             ];
 
             let mut n_configs = 0;
-            let fb_config = unsafe {
-                glx::glXChooseFBConfig(display, screen, fb_attribs.as_ptr(), &mut n_configs)
-            };
+            let fb_config =
+                glx::glXChooseFBConfig(display, screen, fb_attribs.as_ptr(), &mut n_configs);
 
             error_handler.check()?;
             if n_configs <= 0 || fb_config.is_null() {

--- a/src/gl/x11/errors.rs
+++ b/src/gl/x11/errors.rs
@@ -1,0 +1,131 @@
+use std::ffi::CStr;
+use std::fmt::{Debug, Formatter};
+use x11::xlib;
+
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::Mutex;
+
+static CURRENT_ERROR_PTR: AtomicPtr<Mutex<Option<xlib::XErrorEvent>>> =
+    AtomicPtr::new(::std::ptr::null_mut());
+
+/// A helper struct for safe X11 error handling
+pub struct XErrorHandler<'a> {
+    display: *mut xlib::Display,
+    mutex: &'a Mutex<Option<xlib::XErrorEvent>>,
+}
+
+impl<'a> XErrorHandler<'a> {
+    /// Syncs and checks if any previous X11 calls returned an error
+    pub fn check(&mut self) -> Result<(), XLibError> {
+        // Flush all possible previous errors
+        unsafe {
+            xlib::XSync(self.display, 0);
+        }
+        let error = self.mutex.lock().unwrap().take();
+
+        match error {
+            None => Ok(()),
+            Some(inner) => Err(XLibError { inner }),
+        }
+    }
+
+    /// Sets up a temporary X11 error handler for the duration of the given closure, and allows
+    /// that closure to check on the latest X11 error at any time
+    pub fn handle<T, F: FnOnce(&mut XErrorHandler) -> T>(
+        display: *mut xlib::Display,
+        handler: F,
+    ) -> T {
+        unsafe extern "C" fn error_handler(
+            _dpy: *mut xlib::Display,
+            err: *mut xlib::XErrorEvent,
+        ) -> i32 {
+            // SAFETY: the error pointer should be safe to copy
+            let err = *err;
+            // SAFETY: the ptr can only point to a valid instance or be null
+            let mutex = CURRENT_ERROR_PTR.load(Ordering::SeqCst).as_ref();
+            let mutex = if let Some(mutex) = mutex {
+                mutex
+            } else {
+                return 2;
+            };
+
+            match mutex.lock() {
+                Ok(mut current_error) => {
+                    *current_error = Some(err);
+                    0
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[FATAL] raw-gl-context: Failed to lock for X11 Error Handler: {:?}",
+                        e
+                    );
+                    1
+                }
+            }
+        }
+
+        // Flush all possible previous errors
+        unsafe {
+            xlib::XSync(display, 0);
+        }
+
+        let mut mutex = Mutex::new(None);
+        CURRENT_ERROR_PTR.store(&mut mutex, Ordering::SeqCst);
+
+        let old_handler = unsafe { xlib::XSetErrorHandler(Some(error_handler)) };
+        let panic_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            let mut h = XErrorHandler {
+                display,
+                mutex: &mutex,
+            };
+            handler(&mut h)
+        }));
+        // Whatever happened, restore old error handler
+        unsafe { xlib::XSetErrorHandler(old_handler) };
+        CURRENT_ERROR_PTR.store(::core::ptr::null_mut(), Ordering::SeqCst);
+
+        match panic_result {
+            Ok(v) => v,
+            Err(e) => std::panic::resume_unwind(e),
+        }
+    }
+}
+
+pub struct XLibError {
+    inner: xlib::XErrorEvent,
+}
+
+impl XLibError {
+    pub fn get_display_name(&self, buf: &mut [u8]) -> &CStr {
+        unsafe {
+            xlib::XGetErrorText(
+                self.inner.display,
+                self.inner.error_code.into(),
+                buf.as_mut_ptr().cast(),
+                (buf.len() - 1) as i32,
+            );
+        }
+
+        *buf.last_mut().unwrap() = 0;
+        // SAFETY: whatever XGetErrorText did or not, we guaranteed there is a nul byte at the end of the buffer
+        unsafe { CStr::from_ptr(buf.as_mut_ptr().cast()) }
+    }
+}
+
+impl Debug for XLibError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut buf = [0; 255];
+        let display_name = self.get_display_name(&mut buf).to_string_lossy();
+
+        f.debug_struct("XLibError")
+            .field("error_code", &self.inner.error_code)
+            .field("error_message", &display_name)
+            .field("minor_code", &self.inner.minor_code)
+            .field("request_code", &self.inner.request_code)
+            .field("type", &self.inner.type_)
+            .field("resource_id", &self.inner.resourceid)
+            .field("serial", &self.inner.serial)
+            .finish()
+    }
+}

--- a/src/gl/x11/errors.rs
+++ b/src/gl/x11/errors.rs
@@ -45,10 +45,13 @@ impl<'a> XErrorHandler<'a> {
             let err = *err;
 
             CURRENT_X11_ERROR.with(|mutex| match mutex.lock() {
-                Ok(mut current_error) => {
+                // If multiple errors occur, keep the first one since that's likely going to be the
+                // cause of the other errors
+                Ok(mut current_error) if current_error.is_none() => {
                     *current_error = Some(err);
                     0
                 }
+                Ok(_) => 0,
                 Err(e) => {
                     eprintln!(
                         "[FATAL] raw-gl-context: Failed to lock for X11 Error Handler: {:?}",

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -17,6 +17,7 @@
 
 //! Keyboard types.
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use keyboard_types::{Code, Location};
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@ mod window;
 mod window_info;
 mod window_open_options;
 
+#[cfg(feature = "opengl")]
+pub mod gl;
+
 pub use event::*;
 pub use mouse_cursor::MouseCursor;
 pub use window::*;

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -16,7 +16,7 @@ use keyboard_types::KeyboardEvent;
 
 use objc::{msg_send, runtime::Object, sel, sel_impl};
 
-use raw_window_handle::{macos::MacOSHandle, HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{AppKitHandle, HasRawWindowHandle, RawWindowHandle};
 
 use crate::{
     Event, EventStatus, WindowEvent, WindowHandler, WindowInfo, WindowOpenOptions,
@@ -55,7 +55,7 @@ unsafe impl HasRawWindowHandle for WindowHandle {
             }
         }
 
-        RawWindowHandle::MacOS(MacOSHandle { ..MacOSHandle::empty() })
+        RawWindowHandle::AppKit(AppKitHandle::empty())
     }
 }
 
@@ -114,7 +114,7 @@ impl Window {
     {
         let pool = unsafe { NSAutoreleasePool::new(nil) };
 
-        let handle = if let RawWindowHandle::MacOS(handle) = parent.raw_window_handle() {
+        let handle = if let RawWindowHandle::AppKit(handle) = parent.raw_window_handle() {
             handle
         } else {
             panic!("Not a macOS window");
@@ -388,10 +388,10 @@ unsafe impl HasRawWindowHandle for Window {
     fn raw_window_handle(&self) -> RawWindowHandle {
         let ns_window = self.ns_window.unwrap_or(::std::ptr::null_mut()) as *mut c_void;
 
-        RawWindowHandle::MacOS(MacOSHandle {
-            ns_window,
-            ns_view: self.ns_view as *mut c_void,
-            ..MacOSHandle::empty()
-        })
+        let mut handle = AppKitHandle::empty();
+        handle.ns_window = ns_window;
+        handle.ns_view = self.ns_view as *mut c_void;
+
+        RawWindowHandle::AppKit(handle)
     }
 }

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -44,7 +44,7 @@ pub struct WindowHandle {
 
 impl WindowHandle {
     pub fn close(&mut self) {
-        if let Some(_) = self.raw_window_handle.take() {
+        if self.raw_window_handle.take().is_some() {
             self.close_requested.store(true, Ordering::Relaxed);
         }
     }

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -26,6 +26,9 @@ use crate::{
 use super::keyboard::KeyboardState;
 use super::view::{create_view, BASEVIEW_STATE_IVAR};
 
+#[cfg(feature = "opengl")]
+use crate::gl::{GlConfig, GlContext};
+
 pub struct WindowHandle {
     raw_window_handle: Option<RawWindowHandle>,
     close_requested: Arc<AtomicBool>,
@@ -102,6 +105,9 @@ pub struct Window {
     /// Our subclassed NSView
     ns_view: id,
     close_requested: bool,
+
+    #[cfg(feature = "opengl")]
+    gl_context: Option<GlContext>,
 }
 
 impl Window {
@@ -122,7 +128,15 @@ impl Window {
 
         let ns_view = unsafe { create_view(&options) };
 
-        let window = Window { ns_app: None, ns_window: None, ns_view, close_requested: false };
+        let window = Window {
+            ns_app: None,
+            ns_window: None,
+            ns_view,
+            close_requested: false,
+
+            #[cfg(feature = "opengl")]
+            gl_context: options.gl_config.map(Self::create_gl_context),
+        };
 
         let window_handle = Self::init(true, window, build);
 
@@ -146,7 +160,15 @@ impl Window {
 
         let ns_view = unsafe { create_view(&options) };
 
-        let window = Window { ns_app: None, ns_window: None, ns_view, close_requested: false };
+        let window = Window {
+            ns_app: None,
+            ns_window: None,
+            ns_view,
+            close_requested: false,
+
+            #[cfg(feature = "opengl")]
+            gl_context: options.gl_config.map(Self::create_gl_context),
+        };
 
         let window_handle = Self::init(true, window, build);
 
@@ -217,6 +239,9 @@ impl Window {
             ns_window: Some(ns_window),
             ns_view,
             close_requested: false,
+
+            #[cfg(feature = "opengl")]
+            gl_context: options.gl_config.map(Self::create_gl_context),
         };
 
         let _ = Self::init(false, window, build);
@@ -265,6 +290,16 @@ impl Window {
 
     pub fn close(&mut self) {
         self.close_requested = true;
+    }
+
+    #[cfg(feature = "opengl")]
+    pub fn gl_context(&self) -> Option<&GlContext> {
+        self.gl_context.as_ref()
+    }
+
+    #[cfg(feature = "opengl")]
+    fn create_gl_context(config: GlConfig) -> GlContext {
+        todo!("Create the macOS OpenGL context");
     }
 }
 

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -205,11 +205,8 @@ unsafe extern "system" fn wnd_proc(
                 }
             }
             WM_TIMER => {
-                match wparam {
-                    WIN_FRAME_TIMER => {
-                        window_state.handler.on_frame(&mut window);
-                    }
-                    _ => (),
+                if wparam == WIN_FRAME_TIMER {
+                    window_state.handler.on_frame(&mut window);
                 }
                 return 0;
             }
@@ -414,8 +411,8 @@ impl Window {
                     break;
                 }
 
-                TranslateMessage(&mut msg);
-                DispatchMessageW(&mut msg);
+                TranslateMessage(&msg);
+                DispatchMessageW(&msg);
             }
         }
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -91,6 +91,13 @@ impl<'a> Window<'a> {
     pub fn close(&mut self) {
         self.window.close();
     }
+
+    /// If provided, then an OpenGL context will be created for this window. You'll be able to
+    /// access this context through [crate::Window::gl_context].
+    #[cfg(feature = "opengl")]
+    pub fn gl_context(&self) -> Option<&crate::gl::GlContext> {
+        self.window.gl_context()
+    }
 }
 
 unsafe impl<'a> HasRawWindowHandle for Window<'a> {

--- a/src/window.rs
+++ b/src/window.rs
@@ -18,6 +18,12 @@ pub struct WindowHandle {
     phantom: PhantomData<*mut ()>,
 }
 
+/// Quick wrapper to satisfy [HasRawWindowHandle], because of course a raw window handle wouldn't
+/// have a raw window handle, that would be silly.
+pub(crate) struct RawWindowHandleWrapper {
+    pub handle: RawWindowHandle,
+}
+
 impl WindowHandle {
     fn new(window_handle: platform::WindowHandle) -> Self {
         Self { window_handle, phantom: PhantomData::default() }
@@ -103,5 +109,11 @@ impl<'a> Window<'a> {
 unsafe impl<'a> HasRawWindowHandle for Window<'a> {
     fn raw_window_handle(&self) -> RawWindowHandle {
         self.window.raw_window_handle()
+    }
+}
+
+unsafe impl HasRawWindowHandle for RawWindowHandleWrapper {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        self.handle
     }
 }

--- a/src/window_open_options.rs
+++ b/src/window_open_options.rs
@@ -21,4 +21,9 @@ pub struct WindowOpenOptions {
 
     /// The dpi scaling policy
     pub scale: WindowScalePolicy,
+
+    /// If provided, then an OpenGL context will be created for this window. You'll be able to
+    /// access this context through [crate::Window::gl_context].
+    #[cfg(feature = "opengl")]
+    pub gl_config: Option<crate::gl::GlConfig>,
 }

--- a/src/x11/cursor.rs
+++ b/src/x11/cursor.rs
@@ -101,5 +101,5 @@ pub(super) fn get_xcursor(display: *mut x11::xlib::Display, cursor: MouseCursor)
         MouseCursor::RowResize => loadn(&[b"split_v\0", b"v_double_arrow\0"]),
     };
 
-    cursor.or(load(b"left_ptr\0")).unwrap_or(0)
+    cursor.or_else(|| load(b"left_ptr\0")).unwrap_or(0)
 }

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -11,7 +11,6 @@ use xcb::ffi::xcb_screen_t;
 use xcb::StructPtr;
 
 use super::XcbConnection;
-use crate::window::RawWindowHandleWrapper;
 use crate::{
     Event, MouseButton, MouseCursor, MouseEvent, PhyPoint, PhySize, ScrollDelta, WindowEvent,
     WindowHandler, WindowInfo, WindowOpenOptions, WindowScalePolicy,
@@ -20,7 +19,10 @@ use crate::{
 use super::keyboard::{convert_key_press_event, convert_key_release_event};
 
 #[cfg(feature = "opengl")]
-use crate::gl::{platform, GlContext};
+use crate::{
+    gl::{platform, GlContext},
+    window::RawWindowHandleWrapper,
+};
 
 pub struct WindowHandle {
     raw_window_handle: Option<RawWindowHandle>,

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -11,6 +11,7 @@ use xcb::ffi::xcb_screen_t;
 use xcb::StructPtr;
 
 use super::XcbConnection;
+use crate::window::RawWindowHandleWrapper;
 use crate::{
     Event, MouseButton, MouseCursor, MouseEvent, PhyPoint, PhySize, ScrollDelta, WindowEvent,
     WindowHandler, WindowInfo, WindowOpenOptions, WindowScalePolicy,
@@ -108,12 +109,6 @@ pub struct Window {
 
 // Hack to allow sending a RawWindowHandle between threads. Do not make public
 struct SendableRwh(RawWindowHandle);
-
-/// Quick wrapper to satisfy [HasRawWindowHandle], because of course a raw window handle wouldn't
-/// have a raw window handle, that would be silly.
-struct RawWindowHandleWrapper {
-    handle: RawWindowHandle,
-}
 
 unsafe impl Send for SendableRwh {}
 
@@ -664,12 +659,6 @@ unsafe impl HasRawWindowHandle for Window {
         handle.display = self.xcb_connection.conn.get_raw_dpy() as *mut c_void;
 
         RawWindowHandle::Xlib(handle)
-    }
-}
-
-unsafe impl HasRawWindowHandle for RawWindowHandleWrapper {
-    fn raw_window_handle(&self) -> RawWindowHandle {
-        self.handle
     }
 }
 

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::*;
 
-use raw_window_handle::{unix::XlibHandle, HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle, XlibHandle};
 
 use super::XcbConnection;
 use crate::{
@@ -49,7 +49,7 @@ unsafe impl HasRawWindowHandle for WindowHandle {
             }
         }
 
-        RawWindowHandle::Xlib(XlibHandle { ..raw_window_handle::unix::XlibHandle::empty() })
+        RawWindowHandle::Xlib(XlibHandle::empty())
     }
 }
 
@@ -595,11 +595,11 @@ impl Window {
 
 unsafe impl HasRawWindowHandle for Window {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        RawWindowHandle::Xlib(XlibHandle {
-            window: self.window_id as c_ulong,
-            display: self.xcb_connection.conn.get_raw_dpy() as *mut c_void,
-            ..raw_window_handle::unix::XlibHandle::empty()
-        })
+        let mut handle = XlibHandle::empty();
+        handle.window = self.window_id as c_ulong;
+        handle.display = self.xcb_connection.conn.get_raw_dpy() as *mut c_void;
+
+        RawWindowHandle::Xlib(handle)
     }
 }
 

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -16,6 +16,9 @@ use crate::{
 
 use super::keyboard::{convert_key_press_event, convert_key_release_event};
 
+#[cfg(feature = "opengl")]
+use crate::gl::GlContext;
+
 pub struct WindowHandle {
     raw_window_handle: Option<RawWindowHandle>,
     close_requested: Arc<AtomicBool>,
@@ -96,6 +99,9 @@ pub struct Window {
 
     new_physical_size: Option<PhySize>,
     parent_handle: Option<ParentHandle>,
+
+    #[cfg(feature = "opengl")]
+    gl_context: Option<GlContext>,
 }
 
 // Hack to allow sending a RawWindowHandle between threads. Do not make public
@@ -306,6 +312,9 @@ impl Window {
 
             new_physical_size: None,
             parent_handle,
+
+            #[cfg(feature = "opengl")]
+            gl_context: todo!("Create the X11 OpenGL context"),
         };
 
         let mut handler = build(&mut crate::Window::new(&mut window));
@@ -344,6 +353,11 @@ impl Window {
 
     pub fn close(&mut self) {
         self.close_requested = true;
+    }
+
+    #[cfg(feature = "opengl")]
+    pub fn gl_context(&self) -> Option<&crate::gl::GlContext> {
+        self.gl_context.as_ref()
     }
 
     #[inline]

--- a/src/x11/xcb_connection.rs
+++ b/src/x11/xcb_connection.rs
@@ -11,7 +11,6 @@ use super::cursor;
 pub(crate) struct Atoms {
     pub wm_protocols: Option<u32>,
     pub wm_delete_window: Option<u32>,
-    pub wm_normal_hints: Option<u32>,
 }
 
 pub struct XcbConnection {
@@ -20,6 +19,7 @@ pub struct XcbConnection {
 
     pub(crate) atoms: Atoms,
 
+    // FIXME: Same here, there's a ton of unused cursor machinery in here
     pub(super) cursor_cache: HashMap<MouseCursor, u32>,
 }
 
@@ -46,14 +46,13 @@ impl XcbConnection {
 
         conn.set_event_queue_owner(xcb::base::EventQueueOwner::Xcb);
 
-        let (wm_protocols, wm_delete_window, wm_normal_hints) =
-            intern_atoms!(&conn, WM_PROTOCOLS, WM_DELETE_WINDOW, WM_NORMAL_HINTS);
+        let (wm_protocols, wm_delete_window) = intern_atoms!(&conn, WM_PROTOCOLS, WM_DELETE_WINDOW);
 
         Ok(Self {
             conn,
             xlib_display,
 
-            atoms: Atoms { wm_protocols, wm_delete_window, wm_normal_hints },
+            atoms: Atoms { wm_protocols, wm_delete_window },
 
             cursor_cache: HashMap::new(),
         })
@@ -136,7 +135,7 @@ impl XcbConnection {
 
     #[inline]
     pub fn get_scaling(&self) -> Option<f64> {
-        self.get_scaling_xft().or(self.get_scaling_screen_dimensions())
+        self.get_scaling_xft().or_else(|| self.get_scaling_screen_dimensions())
     }
 
     #[inline]


### PR DESCRIPTION
As discussed on the Rust Audio Discord, this is necessary to be able to create an OpenGL context under X11. The OpenGL context configuration determines which framebuffer configuration should be used, but the framebuffer configuration in turn determines which visual should be used for the window the context will be used with. Because of that, it's not possible to create an OpenGL context for an X11 window after the fact. Because of that, the context creation from raw-gl-context's X11 module has now been split up into two parts: initializing the framebuffer config and determining a visual, and another one for actually creating the context after the window has been created. All of the other code from raw-gl-context is unchanged. The version of raw-gl-context used is from @prokopyl's PR adding more error checks on X11 (https://github.com/glowcoil/raw-gl-context/pull/15).

This is all put behind a new `opengl` feature that's disabled by default. The idea is that you can provide the OpenGL context options alongside the other window options, and if that's provided then calling `window.gl_context()` will return an `Option<&GlContext>` so you can access the OpenGL context in your window handler.

I've also taken the liberty to fix a lot of warnings. The main things remaining are a lot of unused cursor functions in the X11 implementation, and the immutable reference to mutable reference cast in the macOS implementation.

I've only tested this on Linux, so I would very much appreciate it if someone on macOS or Windows could test those implementations! On Linux it solves https://github.com/glowcoil/raw-gl-context/issues/2 for both NVIDIA drivers and Mesa, and for 0 and 8 bit alpha buffers. There's currently no example in the repo, but you can try this version of [egui-baseview](https://github.com/BillyDM/egui-baseview) that's updated to work with these changes instead:

```bash
git clone https://github.com/robbert-vdh/egui-baseview.git -b fix/update-dependencies
cargo run --example simple_demo
```

This supersedes #114.