### PR TITLE
Add the active keyboard modifiers to the mouse events

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -32,14 +32,6 @@ pub enum ScrollDelta {
     },
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub struct MouseClick {
-    pub button: MouseButton,
-    pub click_count: usize,
-    /// The logical coordinates of the mouse position
-    pub position: Point,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum MouseEvent {
     /// The mouse cursor was moved
@@ -53,9 +45,6 @@ pub enum MouseEvent {
 
     /// A mouse button was released.
     ButtonReleased(MouseButton),
-
-    /// A mouse button was clicked.
-    Click(MouseClick),
 
     /// The mouse wheel was scrolled.
     WheelScrolled(ScrollDelta),

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,4 @@
-use keyboard_types::KeyboardEvent;
+use keyboard_types::{KeyboardEvent, Modifiers};
 
 use crate::{Point, WindowInfo};
 
@@ -38,21 +38,42 @@ pub enum MouseEvent {
     CursorMoved {
         /// The logical coordinates of the mouse position
         position: Point,
+        /// The modifiers that were held down just before the event.
+        modifiers: Modifiers,
     },
 
     /// A mouse button was pressed.
-    ButtonPressed(MouseButton),
+    ButtonPressed {
+        /// The button that was pressed.
+        button: MouseButton,
+        /// The modifiers that were held down just before the event.
+        modifiers: Modifiers,
+    },
 
     /// A mouse button was released.
-    ButtonReleased(MouseButton),
+    ButtonReleased {
+        /// The button that was released.
+        button: MouseButton,
+        /// The modifiers that were held down just before the event.
+        modifiers: Modifiers,
+    },
 
     /// The mouse wheel was scrolled.
-    WheelScrolled(ScrollDelta),
+    WheelScrolled {
+        /// How much was scrolled, in factional lines.
+        delta: ScrollDelta,
+        /// The modifiers that were held down just before the event.
+        modifiers: Modifiers,
+    },
 
     /// The mouse cursor entered the window.
+    ///
+    /// May not be available on all platforms.
     CursorEntered,
 
     /// The mouse cursor left the window.
+    ///
+    /// May not be available on all platforms.
     CursorLeft,
 }
 

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -19,6 +19,7 @@ use crate::{
     WindowOpenOptions,
 };
 
+use super::keyboard::make_modifiers;
 use super::window::WindowState;
 
 /// Name of the field used to store the `WindowState` pointer.
@@ -33,6 +34,31 @@ macro_rules! add_simple_mouse_class_method {
             };
 
             state.trigger_event(Event::Mouse($event));
+        }
+
+        $class.add_method(
+            sel!($sel:),
+            $sel as extern "C" fn(&Object, Sel, id),
+        );
+    };
+}
+
+/// Similar to [add_simple_mouse_class_method!], but this creates its own event object for the
+/// press/release event and adds the active modifier keys to that event.
+macro_rules! add_mouse_button_class_method {
+    ($class:ident, $sel:ident, $event_ty:ident, $button:expr) => {
+        #[allow(non_snake_case)]
+        extern "C" fn $sel(this: &Object, _: Sel, event: id){
+            let state: &mut WindowState = unsafe {
+                WindowState::from_field(this)
+            };
+
+            let modifiers = unsafe { NSEvent::modifierFlags(event) };
+
+            state.trigger_event(Event::Mouse($event_ty {
+                button: $button,
+                modifiers: make_modifiers(modifiers),
+            }));
         }
 
         $class.add_method(
@@ -126,12 +152,12 @@ unsafe fn create_view_class() -> &'static Class {
         view_did_change_backing_properties as extern "C" fn(&Object, Sel, id),
     );
 
-    add_simple_mouse_class_method!(class, mouseDown, ButtonPressed(MouseButton::Left));
-    add_simple_mouse_class_method!(class, mouseUp, ButtonReleased(MouseButton::Left));
-    add_simple_mouse_class_method!(class, rightMouseDown, ButtonPressed(MouseButton::Right));
-    add_simple_mouse_class_method!(class, rightMouseUp, ButtonReleased(MouseButton::Right));
-    add_simple_mouse_class_method!(class, otherMouseDown, ButtonPressed(MouseButton::Middle));
-    add_simple_mouse_class_method!(class, otherMouseUp, ButtonReleased(MouseButton::Middle));
+    add_mouse_button_class_method!(class, mouseDown, ButtonPressed, MouseButton::Left);
+    add_mouse_button_class_method!(class, mouseUp, ButtonReleased, MouseButton::Left);
+    add_mouse_button_class_method!(class, rightMouseDown, ButtonPressed, MouseButton::Right);
+    add_mouse_button_class_method!(class, rightMouseUp, ButtonReleased, MouseButton::Right);
+    add_mouse_button_class_method!(class, otherMouseDown, ButtonPressed, MouseButton::Middle);
+    add_mouse_button_class_method!(class, otherMouseUp, ButtonReleased, MouseButton::Middle);
     add_simple_mouse_class_method!(class, mouseEntered, MouseEvent::CursorEntered);
     add_simple_mouse_class_method!(class, mouseExited, MouseEvent::CursorLeft);
 
@@ -308,8 +334,12 @@ extern "C" fn mouse_moved(this: &Object, _sel: Sel, event: id) {
 
         msg_send![this, convertPoint:point fromView:nil]
     };
+    let modifiers = unsafe { NSEvent::modifierFlags(event) };
 
     let position = Point { x: point.x, y: point.y };
 
-    state.trigger_event(Event::Mouse(MouseEvent::CursorMoved { position }));
+    state.trigger_event(Event::Mouse(MouseEvent::CursorMoved {
+        position,
+        modifiers: make_modifiers(modifiers),
+    }));
 }

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -137,13 +137,14 @@ unsafe extern "system" fn wnd_proc(
                 let y = ((lparam >> 16) & 0xFFFF) as i16 as i32;
 
                 let physical_pos = PhyPoint { x, y };
-
                 let logical_pos = physical_pos.to_logical(&window_state.window_info);
+                let event = Event::Mouse(MouseEvent::CursorMoved {
+                    position: logical_pos,
+                    modifiers: window_state.keyboard_state.get_modifiers_from_mouse_wparam(wparam),
+                });
 
-                window_state.handler.on_event(
-                    &mut window,
-                    Event::Mouse(MouseEvent::CursorMoved { position: logical_pos }),
-                );
+                window_state.handler.on_event(&mut window, event);
+
                 return 0;
             }
             WM_MOUSEWHEEL => {
@@ -155,13 +156,13 @@ unsafe extern "system" fn wnd_proc(
                 let value = value as i32;
                 let value = value as f32 / WHEEL_DELTA as f32;
 
-                window_state.handler.on_event(
-                    &mut window,
-                    Event::Mouse(MouseEvent::WheelScrolled(ScrollDelta::Lines {
-                        x: 0.0,
-                        y: value,
-                    })),
-                );
+                let event = Event::Mouse(MouseEvent::WheelScrolled {
+                    delta: ScrollDelta::Lines { x: 0.0, y: value },
+                    modifiers: window_state.keyboard_state.get_modifiers_from_mouse_wparam(wparam),
+                });
+
+                window_state.handler.on_event(&mut window, event);
+
                 return 0;
             }
             WM_LBUTTONDOWN | WM_LBUTTONUP | WM_MBUTTONDOWN | WM_MBUTTONUP | WM_RBUTTONDOWN
@@ -190,7 +191,12 @@ unsafe extern "system" fn wnd_proc(
                             // Capture the mouse cursor on button down
                             mouse_button_counter = mouse_button_counter.saturating_add(1);
                             SetCapture(hwnd);
-                            MouseEvent::ButtonPressed(button)
+                            MouseEvent::ButtonPressed {
+                                button,
+                                modifiers: window_state
+                                    .keyboard_state
+                                    .get_modifiers_from_mouse_wparam(wparam),
+                            }
                         }
                         WM_LBUTTONUP | WM_MBUTTONUP | WM_RBUTTONUP | WM_XBUTTONUP => {
                             // Release the mouse cursor capture when all buttons are released
@@ -199,7 +205,12 @@ unsafe extern "system" fn wnd_proc(
                                 ReleaseCapture();
                             }
 
-                            MouseEvent::ButtonReleased(button)
+                            MouseEvent::ButtonReleased {
+                                button,
+                                modifiers: window_state
+                                    .keyboard_state
+                                    .get_modifiers_from_mouse_wparam(wparam),
+                            }
                         }
                         _ => {
                             unreachable!()

--- a/src/x11/keyboard.rs
+++ b/src/x11/keyboard.rs
@@ -362,7 +362,7 @@ fn hardware_keycode_to_code(hw_keycode: u16) -> Code {
 
 // Extracts the keyboard modifiers from, e.g., the `state` field of
 // `xcb::xproto::ButtonPressEvent`
-fn key_mods(mods: u16) -> Modifiers {
+pub(super) fn key_mods(mods: u16) -> Modifiers {
     let mut ret = Modifiers::default();
     let mut key_masks = [
         (xproto::MOD_MASK_SHIFT, Modifiers::SHIFT),

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -16,7 +16,7 @@ use crate::{
     WindowHandler, WindowInfo, WindowOpenOptions, WindowScalePolicy,
 };
 
-use super::keyboard::{convert_key_press_event, convert_key_release_event};
+use super::keyboard::{convert_key_press_event, convert_key_release_event, key_mods};
 
 #[cfg(feature = "opengl")]
 use crate::{
@@ -580,7 +580,10 @@ impl Window {
 
                     handler.on_event(
                         &mut crate::Window::new(self),
-                        Event::Mouse(MouseEvent::CursorMoved { position: logical_pos }),
+                        Event::Mouse(MouseEvent::CursorMoved {
+                            position: logical_pos,
+                            modifiers: key_mods(event.state()),
+                        }),
                     );
                 }
             }
@@ -593,26 +596,29 @@ impl Window {
                     4 => {
                         handler.on_event(
                             &mut crate::Window::new(self),
-                            Event::Mouse(MouseEvent::WheelScrolled(ScrollDelta::Lines {
-                                x: 0.0,
-                                y: 1.0,
-                            })),
+                            Event::Mouse(MouseEvent::WheelScrolled {
+                                delta: ScrollDelta::Lines { x: 0.0, y: 1.0 },
+                                modifiers: key_mods(event.state()),
+                            }),
                         );
                     }
                     5 => {
                         handler.on_event(
                             &mut crate::Window::new(self),
-                            Event::Mouse(MouseEvent::WheelScrolled(ScrollDelta::Lines {
-                                x: 0.0,
-                                y: -1.0,
-                            })),
+                            Event::Mouse(MouseEvent::WheelScrolled {
+                                delta: ScrollDelta::Lines { x: 0.0, y: -1.0 },
+                                modifiers: key_mods(event.state()),
+                            }),
                         );
                     }
                     detail => {
                         let button_id = mouse_id(detail);
                         handler.on_event(
                             &mut crate::Window::new(self),
-                            Event::Mouse(MouseEvent::ButtonPressed(button_id)),
+                            Event::Mouse(MouseEvent::ButtonPressed {
+                                button: button_id,
+                                modifiers: key_mods(event.state()),
+                            }),
                         );
                     }
                 }
@@ -626,7 +632,10 @@ impl Window {
                     let button_id = mouse_id(detail);
                     handler.on_event(
                         &mut crate::Window::new(self),
-                        Event::Mouse(MouseEvent::ButtonReleased(button_id)),
+                        Event::Mouse(MouseEvent::ButtonReleased {
+                            button: button_id,
+                            modifiers: key_mods(event.state()),
+                        }),
                     );
                 }
             }


### PR DESCRIPTION
This builds on top of #115, so I marked this as a draft until that has been merged.

Every mouse event now has a modifier field containing the current keyboard modifiers. Most window management APIs work like this, and it solves things like #116 by making sure that whenever a window receives a mouse event, it also knows the up to date keyboard modifier status.