### PR TITLE
Allow taking ownership of the OpenGL context

### DIFF
--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -303,8 +303,8 @@ impl Window {
     }
 
     #[cfg(feature = "opengl")]
-    pub fn gl_context(&self) -> Option<&GlContext> {
-        self.gl_context.as_ref()
+    pub fn gl_context(&mut self) -> Option<GlContext> {
+        self.gl_context.take()
     }
 
     #[cfg(feature = "opengl")]

--- a/src/window.rs
+++ b/src/window.rs
@@ -98,10 +98,11 @@ impl<'a> Window<'a> {
         self.window.close();
     }
 
-    /// If provided, then an OpenGL context will be created for this window. You'll be able to
-    /// access this context through [crate::Window::gl_context].
+    /// If the window has been created with [`WindowOpenOptions::gl_config`] set, then this will
+    /// contain the OpenGL context. Calling this function will take ownership of that OpenGL
+    /// context, so you can do this once after which you will need to store the context yourself.
     #[cfg(feature = "opengl")]
-    pub fn gl_context(&self) -> Option<&crate::gl::GlContext> {
+    pub fn gl_context(&mut self) -> Option<crate::gl::GlContext> {
         self.window.gl_context()
     }
 }

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -390,8 +390,8 @@ impl Window {
     }
 
     #[cfg(feature = "opengl")]
-    pub fn gl_context(&self) -> Option<&crate::gl::GlContext> {
-        self.gl_context.as_ref()
+    pub fn gl_context(&mut self) -> Option<GlContext> {
+        self.gl_context.take()
     }
 
     fn find_visual_for_depth(screen: &StructPtr<xcb_screen_t>, depth: u8) -> Option<u32> {


### PR DESCRIPTION
This is a follow up to #115. Having the window own the context seemed like a sensible approach to me since there's an `on_frame()` callback where you'd do your rendering, but some integrations like @BillyDM's [iced_baseview](https://github.com/BillyDM/iced_baseview/) do the rendering from a separate `Send + Sync + 'static` context, and you thus need to be able to move the OpenGL context into there. This change means that you'll need to move the `GlContext` into your window handle struct when first creating it by calling `window.gl_context().take()`.