### PR TITLE
WIP: Input focus handling

### DIFF
--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -298,6 +298,14 @@ impl Window {
         window_handle
     }
 
+    pub fn set_input_focus(&mut self) {
+        //TODO
+    }
+
+    pub fn release_input_focus(&mut self) {
+        //TODO
+    }
+
     pub fn close(&mut self) {
         self.close_requested = true;
     }

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -5,7 +5,7 @@ use winapi::um::combaseapi::CoCreateGuid;
 use winapi::um::winuser::{
     AdjustWindowRectEx, CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW,
     GetDpiForWindow, GetMessageW, GetWindowLongPtrW, LoadCursorW, PostMessageW, RegisterClassW,
-    ReleaseCapture, SetCapture, SetProcessDpiAwarenessContext, SetTimer, SetWindowLongPtrW,
+    ReleaseCapture, SetCapture, SetFocus, SetProcessDpiAwarenessContext, SetTimer, SetWindowLongPtrW,
     SetWindowPos, TranslateMessage, UnregisterClassW, CS_OWNDC, GET_XBUTTON_WPARAM, GWLP_USERDATA,
     IDC_ARROW, MSG, SWP_NOMOVE, SWP_NOZORDER, WHEEL_DELTA, WM_CHAR, WM_CLOSE, WM_CREATE,
     WM_DPICHANGED, WM_INPUTLANGCHANGE, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP,
@@ -190,6 +190,7 @@ unsafe extern "system" fn wnd_proc(
                             // Capture the mouse cursor on button down
                             mouse_button_counter = mouse_button_counter.saturating_add(1);
                             SetCapture(hwnd);
+                            SetFocus(hwnd);
                             MouseEvent::ButtonPressed(button)
                         }
                         WM_LBUTTONUP | WM_MBUTTONUP | WM_RBUTTONUP | WM_XBUTTONUP => {

--- a/src/window.rs
+++ b/src/window.rs
@@ -28,7 +28,7 @@ impl WindowHandle {
     fn new(window_handle: platform::WindowHandle) -> Self {
         Self { window_handle, phantom: PhantomData::default() }
     }
-
+    
     /// Close the window
     pub fn close(&mut self) {
         self.window_handle.close();
@@ -91,6 +91,14 @@ impl<'a> Window<'a> {
         B: Send + 'static,
     {
         platform::Window::open_blocking::<H, B>(options, build)
+    }
+
+    pub fn set_input_focus(&mut self){
+        self.window.set_input_focus();
+    }
+
+    pub fn release_input_focus(&mut self){
+        self.window.release_input_focus();
     }
 
     /// Close the window

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -385,6 +385,14 @@ impl Window {
         self.mouse_cursor = mouse_cursor;
     }
 
+    pub fn set_input_focus(&mut self) {
+        //TODO
+    }
+
+    pub fn release_input_focus(&mut self) {
+        //TODO
+    }
+
     pub fn close(&mut self) {
         self.close_requested = true;
     }


### PR DESCRIPTION
When a child window is spawned by `open_parented` the KEYUP/KEYDOWN events are still sent to the parent. This makes it so the child becomes focused so key events can go to its wnd_proc function.