### PR TITLE
Support horizontal scrolling on Linux and Windows

### DIFF
--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -9,10 +9,11 @@ use winapi::um::winuser::{
     SetWindowPos, TranslateMessage, UnregisterClassW, CS_OWNDC, GET_XBUTTON_WPARAM, GWLP_USERDATA,
     IDC_ARROW, MSG, SWP_NOMOVE, SWP_NOZORDER, WHEEL_DELTA, WM_CHAR, WM_CLOSE, WM_CREATE,
     WM_DPICHANGED, WM_INPUTLANGCHANGE, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP,
-    WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_NCDESTROY, WM_RBUTTONDOWN,
-    WM_RBUTTONUP, WM_SHOWWINDOW, WM_SIZE, WM_SYSCHAR, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_TIMER,
-    WM_USER, WM_XBUTTONDOWN, WM_XBUTTONUP, WNDCLASSW, WS_CAPTION, WS_CHILD, WS_CLIPSIBLINGS,
-    WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUPWINDOW, WS_SIZEBOX, WS_VISIBLE, XBUTTON1, XBUTTON2,
+    WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_NCDESTROY,
+    WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SHOWWINDOW, WM_SIZE, WM_SYSCHAR, WM_SYSKEYDOWN, WM_SYSKEYUP,
+    WM_TIMER, WM_USER, WM_XBUTTONDOWN, WM_XBUTTONUP, WNDCLASSW, WS_CAPTION, WS_CHILD,
+    WS_CLIPSIBLINGS, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUPWINDOW, WS_SIZEBOX, WS_VISIBLE,
+    XBUTTON1, XBUTTON2,
 };
 
 use std::cell::RefCell;
@@ -147,7 +148,7 @@ unsafe extern "system" fn wnd_proc(
 
                 return 0;
             }
-            WM_MOUSEWHEEL => {
+            WM_MOUSEWHEEL | WM_MOUSEHWHEEL => {
                 let mut window_state = (*window_state_ptr).borrow_mut();
                 let mut window = window_state.create_window(hwnd);
                 let mut window = crate::Window::new(&mut window);
@@ -157,7 +158,11 @@ unsafe extern "system" fn wnd_proc(
                 let value = value as f32 / WHEEL_DELTA as f32;
 
                 let event = Event::Mouse(MouseEvent::WheelScrolled {
-                    delta: ScrollDelta::Lines { x: 0.0, y: value },
+                    delta: if msg == WM_MOUSEWHEEL {
+                        ScrollDelta::Lines { x: 0.0, y: value }
+                    } else {
+                        ScrollDelta::Lines { x: value, y: 0.0 }
+                    },
                     modifiers: window_state.keyboard_state.get_modifiers_from_mouse_wparam(wparam),
                 });
 

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -684,8 +684,8 @@ fn mouse_id(id: u8) -> MouseButton {
         1 => MouseButton::Left,
         2 => MouseButton::Middle,
         3 => MouseButton::Right,
-        6 => MouseButton::Back,
-        7 => MouseButton::Forward,
+        8 => MouseButton::Back,
+        9 => MouseButton::Forward,
         id => MouseButton::Other(id),
     }
 }

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -596,20 +596,17 @@ impl Window {
                 let detail = event.detail();
 
                 match detail {
-                    4 => {
+                    4..=7 => {
                         handler.on_event(
                             &mut crate::Window::new(self),
                             Event::Mouse(MouseEvent::WheelScrolled {
-                                delta: ScrollDelta::Lines { x: 0.0, y: 1.0 },
-                                modifiers: key_mods(event.state()),
-                            }),
-                        );
-                    }
-                    5 => {
-                        handler.on_event(
-                            &mut crate::Window::new(self),
-                            Event::Mouse(MouseEvent::WheelScrolled {
-                                delta: ScrollDelta::Lines { x: 0.0, y: -1.0 },
+                                delta: match detail {
+                                    4 => ScrollDelta::Lines { x: 0.0, y: 1.0 },
+                                    5 => ScrollDelta::Lines { x: 0.0, y: -1.0 },
+                                    6 => ScrollDelta::Lines { x: -1.0, y: 0.0 },
+                                    7 => ScrollDelta::Lines { x: 1.0, y: 0.0 },
+                                    _ => unreachable!(),
+                                },
                                 modifiers: key_mods(event.state()),
                             }),
                         );
@@ -631,7 +628,7 @@ impl Window {
                 let event = unsafe { xcb::cast_event::<xcb::ButtonPressEvent>(&event) };
                 let detail = event.detail();
 
-                if detail != 4 && detail != 5 {
+                if !(4..=7).contains(&detail) {
                     let button_id = mouse_id(detail);
                     handler.on_event(
                         &mut crate::Window::new(self),


### PR DESCRIPTION
I noticed that on Linux horizontal scrolling (using one of those mouse wheels that can be pushed to the left and to the right like on the Logitech G502) was incorrectly bound to the mouse forwards and back buttons. This PR fixes the button assignments for those buttons (buttons 8 and 9 map to those), and it adds horizontal scrolling support for both Linux/X11 and Windows. I haven't tested whether horizontal scrolling works on macOS but looking at the [`scroll_wheel()`](https://github.com/RustAudio/baseview/blob/84f10763a35ec07de5f2dd32bdb68649ef465e4e/src/macos/view.rs#L349C13-L369) handler presumably that already worked just fine.