### PR TITLE
Support resizing windows after creation

### DIFF
--- a/src/gl/macos.rs
+++ b/src/gl/macos.rs
@@ -11,6 +11,7 @@ use cocoa::appkit::{
     NSOpenGLProfileVersionLegacy, NSOpenGLView, NSView,
 };
 use cocoa::base::{id, nil, YES};
+use cocoa::foundation::NSSize;
 
 use core_foundation::base::TCFType;
 use core_foundation::bundle::{CFBundleGetBundleWithIdentifier, CFBundleGetFunctionPointerForName};
@@ -132,6 +133,14 @@ impl GlContext {
         unsafe {
             self.context.flushBuffer();
             let () = msg_send![self.view, setNeedsDisplay: YES];
+        }
+    }
+
+    /// On macOS the `NSOpenGLView` needs to be resized separtely from our main view.
+    pub(crate) fn resize(&self, size: NSSize) {
+        unsafe { NSView::setFrameSize(self.view, size) };
+        unsafe {
+            let _: () = msg_send![self.view, setNeedsDisplay: YES];
         }
     }
 }

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -106,4 +106,10 @@ impl GlContext {
     pub fn swap_buffers(&self) {
         self.context.swap_buffers();
     }
+
+    /// On macOS the `NSOpenGLView` needs to be resized separtely from our main view.
+    #[cfg(target_os = "macos")]
+    pub(crate) fn resize(&self, size: cocoa::foundation::NSSize) {
+        self.context.resize(size);
+    }
 }

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -240,12 +240,17 @@ extern "C" fn view_did_change_backing_properties(this: &Object, _: Sel, _: id) {
 
         let bounds: NSRect = msg_send![this, bounds];
 
-        let window_info = WindowInfo::from_logical_size(
+        let new_window_info = WindowInfo::from_logical_size(
             Size::new(bounds.size.width, bounds.size.height),
             scale_factor,
         );
 
-        state.trigger_event(Event::Window(WindowEvent::Resized(window_info)));
+        // Only send the event when the window's size has actually changed to be in line with the
+        // other platform implementations
+        if new_window_info.physical_size() != state.window_info.physical_size() {
+            state.window_info = new_window_info;
+            state.trigger_event(Event::Window(WindowEvent::Resized(new_window_info)));
+        }
     }
 }
 
@@ -364,6 +369,6 @@ extern "C" fn scroll_wheel(this: &Object, _: Sel, event: id) {
 
     state.trigger_event(Event::Mouse(MouseEvent::WheelScrolled {
         delta,
-        modifiers: make_modifiers(modifiers)
+        modifiers: make_modifiers(modifiers),
     }));
 }

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -234,7 +234,7 @@ extern "C" fn view_did_change_backing_properties(this: &Object, _: Sel, _: id) {
         let ns_window: *mut Object = msg_send![this, window];
 
         let scale_factor: f64 =
-            if ns_window.is_null() { 1.0 } else { NSWindow::backingScaleFactor(ns_window) as f64 };
+            if ns_window.is_null() { 1.0 } else { NSWindow::backingScaleFactor(ns_window) };
 
         let state: &mut WindowState = WindowState::from_field(this);
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -229,10 +229,7 @@ impl Window {
 
         let rect = NSRect::new(
             NSPoint::new(0.0, 0.0),
-            NSSize::new(
-                window_info.logical_size().width as f64,
-                window_info.logical_size().height as f64,
-            ),
+            NSSize::new(window_info.logical_size().width, window_info.logical_size().height),
         );
 
         let ns_window = unsafe {

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -320,7 +320,9 @@ impl Window {
     }
 
     pub fn resize(&mut self, size: Size) {
-        let size = NSSize::new(size.width, size.height);
+        // NOTE: macOS gives you a personal rave if you pass in fractional pixels here. Even though
+        //       the size is in fractional pixels.
+        let size = NSSize::new(size.width.round(), size.height.round());
 
         unsafe { NSView::setFrameSize(self.ns_view, size) };
         unsafe {

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -336,7 +336,12 @@ impl Window {
         // If this is a standalone window then we'll also need to resize the window itself
         if let Some(ns_window) = self.ns_window {
             let mut frame = unsafe { NSWindow::frame(ns_window) };
+
+            // macOS wants you to manually add the size of the window decorations to the frame's
+            // size
             frame.size = size;
+            let frame = unsafe { NSWindow::frameRectForContentRect_(ns_window, frame) };
+
             unsafe { NSWindow::setFrame_display_(ns_window, frame, YES) }
         }
     }

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -337,14 +337,7 @@ impl Window {
 
         // If this is a standalone window then we'll also need to resize the window itself
         if let Some(ns_window) = self.ns_window {
-            let mut frame = unsafe { NSWindow::frame(ns_window) };
-
-            // macOS wants you to manually add the size of the window decorations to the frame's
-            // size
-            frame.size = size;
-            let frame = unsafe { NSWindow::frameRectForContentRect_(ns_window, frame) };
-
-            unsafe { NSWindow::setFrame_display_(ns_window, frame, YES) }
+            unsafe { NSWindow::setContentSize_(ns_window, size) };
         }
     }
 

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -17,6 +17,7 @@ use winapi::um::winuser::{
 };
 
 use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
 use std::ffi::{c_void, OsStr};
 use std::marker::PhantomData;
 use std::os::windows::ffi::OsStrExt;
@@ -29,8 +30,8 @@ use raw_window_handle::{HasRawWindowHandle, RawWindowHandle, Win32Handle};
 const BV_WINDOW_MUST_CLOSE: UINT = WM_USER + 1;
 
 use crate::{
-    Event, MouseButton, MouseEvent, PhyPoint, PhySize, ScrollDelta, WindowEvent, WindowHandler,
-    WindowInfo, WindowOpenOptions, WindowScalePolicy,
+    Event, MouseButton, MouseEvent, PhyPoint, PhySize, ScrollDelta, Size, WindowEvent,
+    WindowHandler, WindowInfo, WindowOpenOptions, WindowScalePolicy,
 };
 
 use super::keyboard::KeyboardState;
@@ -130,232 +131,259 @@ unsafe extern "system" fn wnd_proc(
     if !window_state_ptr.is_null() {
         let window_state = &*window_state_ptr;
 
-        match msg {
-            WM_MOUSEMOVE => {
-                let mut window = window_state.create_window(hwnd);
-                let mut window = crate::Window::new(&mut window);
+        let result = wnd_proc_inner(hwnd, msg, wparam, lparam, window_state);
 
-                let x = (lparam & 0xFFFF) as i16 as i32;
-                let y = ((lparam >> 16) & 0xFFFF) as i16 as i32;
+        // If any of the above event handlers caused tasks to be pushed to the deferred tasks list,
+        // then we'll try to handle them now
+        loop {
+            // NOTE: This is written like this instead of using a `while let` loop to avoid exending
+            //       the borrow of `window_state.deferred_tasks` into the call of
+            //       `window_state.handle_deferred_task()` since that may also generate additional
+            //       messages.
+            let task = match window_state.deferred_tasks.borrow_mut().pop_front() {
+                Some(task) => task,
+                None => break,
+            };
 
-                let physical_pos = PhyPoint { x, y };
-                let logical_pos = physical_pos.to_logical(&window_state.window_info.borrow());
-                let event = Event::Mouse(MouseEvent::CursorMoved {
-                    position: logical_pos,
-                    modifiers: window_state
-                        .keyboard_state
-                        .borrow()
-                        .get_modifiers_from_mouse_wparam(wparam),
-                });
+            window_state.handle_deferred_task(task);
+        }
 
-                window_state.handler.borrow_mut().on_event(&mut window, event);
-
-                return 0;
-            }
-            WM_MOUSEWHEEL | WM_MOUSEHWHEEL => {
-                let mut window = window_state.create_window(hwnd);
-                let mut window = crate::Window::new(&mut window);
-
-                let value = (wparam >> 16) as i16;
-                let value = value as i32;
-                let value = value as f32 / WHEEL_DELTA as f32;
-
-                let event = Event::Mouse(MouseEvent::WheelScrolled {
-                    delta: if msg == WM_MOUSEWHEEL {
-                        ScrollDelta::Lines { x: 0.0, y: value }
-                    } else {
-                        ScrollDelta::Lines { x: value, y: 0.0 }
-                    },
-                    modifiers: window_state
-                        .keyboard_state
-                        .borrow()
-                        .get_modifiers_from_mouse_wparam(wparam),
-                });
-
-                window_state.handler.borrow_mut().on_event(&mut window, event);
-
-                return 0;
-            }
-            WM_LBUTTONDOWN | WM_LBUTTONUP | WM_MBUTTONDOWN | WM_MBUTTONUP | WM_RBUTTONDOWN
-            | WM_RBUTTONUP | WM_XBUTTONDOWN | WM_XBUTTONUP => {
-                let mut window = window_state.create_window(hwnd);
-                let mut window = crate::Window::new(&mut window);
-
-                let mut mouse_button_counter = window_state.mouse_button_counter.get();
-
-                let button = match msg {
-                    WM_LBUTTONDOWN | WM_LBUTTONUP => Some(MouseButton::Left),
-                    WM_MBUTTONDOWN | WM_MBUTTONUP => Some(MouseButton::Middle),
-                    WM_RBUTTONDOWN | WM_RBUTTONUP => Some(MouseButton::Right),
-                    WM_XBUTTONDOWN | WM_XBUTTONUP => match GET_XBUTTON_WPARAM(wparam) {
-                        XBUTTON1 => Some(MouseButton::Back),
-                        XBUTTON2 => Some(MouseButton::Forward),
-                        _ => None,
-                    },
-                    _ => None,
-                };
-
-                if let Some(button) = button {
-                    let event = match msg {
-                        WM_LBUTTONDOWN | WM_MBUTTONDOWN | WM_RBUTTONDOWN | WM_XBUTTONDOWN => {
-                            // Capture the mouse cursor on button down
-                            mouse_button_counter = mouse_button_counter.saturating_add(1);
-                            SetCapture(hwnd);
-                            MouseEvent::ButtonPressed {
-                                button,
-                                modifiers: window_state
-                                    .keyboard_state
-                                    .borrow()
-                                    .get_modifiers_from_mouse_wparam(wparam),
-                            }
-                        }
-                        WM_LBUTTONUP | WM_MBUTTONUP | WM_RBUTTONUP | WM_XBUTTONUP => {
-                            // Release the mouse cursor capture when all buttons are released
-                            mouse_button_counter = mouse_button_counter.saturating_sub(1);
-                            if mouse_button_counter == 0 {
-                                ReleaseCapture();
-                            }
-
-                            MouseEvent::ButtonReleased {
-                                button,
-                                modifiers: window_state
-                                    .keyboard_state
-                                    .borrow()
-                                    .get_modifiers_from_mouse_wparam(wparam),
-                            }
-                        }
-                        _ => {
-                            unreachable!()
-                        }
-                    };
-
-                    window_state.mouse_button_counter.set(mouse_button_counter);
-
-                    window_state.handler.borrow_mut().on_event(&mut window, Event::Mouse(event));
-                }
-            }
-            WM_TIMER => {
-                let mut window = window_state.create_window(hwnd);
-                let mut window = crate::Window::new(&mut window);
-
-                if wparam == WIN_FRAME_TIMER {
-                    window_state.handler.borrow_mut().on_frame(&mut window);
-                }
-                return 0;
-            }
-            WM_CLOSE => {
-                // Make sure to release the borrow before the DefWindowProc call
-                {
-                    let mut window = window_state.create_window(hwnd);
-                    let mut window = crate::Window::new(&mut window);
-
-                    window_state
-                        .handler
-                        .borrow_mut()
-                        .on_event(&mut window, Event::Window(WindowEvent::WillClose));
-                }
-
-                // DestroyWindow(hwnd);
-                // return 0;
-                return DefWindowProcW(hwnd, msg, wparam, lparam);
-            }
-            WM_CHAR | WM_SYSCHAR | WM_KEYDOWN | WM_SYSKEYDOWN | WM_KEYUP | WM_SYSKEYUP
-            | WM_INPUTLANGCHANGE => {
-                let mut window = window_state.create_window(hwnd);
-                let mut window = crate::Window::new(&mut window);
-
-                let opt_event = window_state
-                    .keyboard_state
-                    .borrow_mut()
-                    .process_message(hwnd, msg, wparam, lparam);
-
-                if let Some(event) = opt_event {
-                    window_state.handler.borrow_mut().on_event(&mut window, Event::Keyboard(event));
-                }
-
-                if msg != WM_SYSKEYDOWN {
-                    return 0;
-                }
-            }
-            WM_SIZE => {
-                let mut window = window_state.create_window(hwnd);
-                let mut window = crate::Window::new(&mut window);
-
-                let width = (lparam & 0xFFFF) as u16 as u32;
-                let height = ((lparam >> 16) & 0xFFFF) as u16 as u32;
-
-                let window_info = {
-                    let mut window_info = window_state.window_info.borrow_mut();
-                    *window_info = WindowInfo::from_physical_size(
-                        PhySize { width, height },
-                        window_info.scale(),
-                    );
-
-                    window_info.clone()
-                };
-
-                window_state
-                    .handler
-                    .borrow_mut()
-                    .on_event(&mut window, Event::Window(WindowEvent::Resized(window_info)));
-            }
-            WM_DPICHANGED => {
-                // To avoid weirdness with the realtime borrow checker.
-                let new_rect = {
-                    if let WindowScalePolicy::SystemScaleFactor = window_state.scale_policy {
-                        let dpi = (wparam & 0xFFFF) as u16 as u32;
-                        let scale_factor = dpi as f64 / 96.0;
-
-                        let mut window_info = window_state.window_info.borrow_mut();
-                        *window_info =
-                            WindowInfo::from_logical_size(window_info.logical_size(), scale_factor);
-
-                        Some((
-                            RECT {
-                                left: 0,
-                                top: 0,
-                                // todo: check if usize fits into i32
-                                right: window_info.physical_size().width as i32,
-                                bottom: window_info.physical_size().height as i32,
-                            },
-                            window_state.dw_style,
-                        ))
-                    } else {
-                        None
-                    }
-                };
-                if let Some((mut new_rect, dw_style)) = new_rect {
-                    // Convert this desired "client rectangle" size to the actual "window rectangle"
-                    // size (Because of course you have to do that).
-                    AdjustWindowRectEx(&mut new_rect, dw_style, 0, 0);
-
-                    // Windows makes us resize the window manually. This will trigger another `WM_SIZE` event,
-                    // which we can then send the user the new scale factor.
-                    SetWindowPos(
-                        hwnd,
-                        hwnd,
-                        new_rect.left as i32,
-                        new_rect.top as i32,
-                        new_rect.right - new_rect.left,
-                        new_rect.bottom - new_rect.top,
-                        SWP_NOZORDER | SWP_NOMOVE,
-                    );
-                }
-            }
-            WM_NCDESTROY => {
-                unregister_wnd_class(window_state.window_class);
-                SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);
-            }
-            _ => {
-                if msg == BV_WINDOW_MUST_CLOSE {
-                    DestroyWindow(hwnd);
-                    return 0;
-                }
-            }
+        // The actual custom window proc has been moved to another function so we can always handle
+        // the deferred tasks regardless of whether the custom window proc returns early or not
+        if let Some(result) = result {
+            return result;
         }
     }
 
     DefWindowProcW(hwnd, msg, wparam, lparam)
+}
+
+/// Our custom `wnd_proc` handler. If the result contains a value, then this is returned after
+/// handling any deferred tasks. otherwise the default window procedure is invoked.
+unsafe fn wnd_proc_inner(
+    hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM, window_state: &WindowState,
+) -> Option<LRESULT> {
+    match msg {
+        WM_MOUSEMOVE => {
+            let mut window = window_state.create_window(hwnd);
+            let mut window = crate::Window::new(&mut window);
+
+            let x = (lparam & 0xFFFF) as i16 as i32;
+            let y = ((lparam >> 16) & 0xFFFF) as i16 as i32;
+
+            let physical_pos = PhyPoint { x, y };
+            let logical_pos = physical_pos.to_logical(&window_state.window_info.borrow());
+            let event = Event::Mouse(MouseEvent::CursorMoved {
+                position: logical_pos,
+                modifiers: window_state
+                    .keyboard_state
+                    .borrow()
+                    .get_modifiers_from_mouse_wparam(wparam),
+            });
+
+            window_state.handler.borrow_mut().on_event(&mut window, event);
+
+            return Some(0);
+        }
+        WM_MOUSEWHEEL | WM_MOUSEHWHEEL => {
+            let mut window = window_state.create_window(hwnd);
+            let mut window = crate::Window::new(&mut window);
+
+            let value = (wparam >> 16) as i16;
+            let value = value as i32;
+            let value = value as f32 / WHEEL_DELTA as f32;
+
+            let event = Event::Mouse(MouseEvent::WheelScrolled {
+                delta: if msg == WM_MOUSEWHEEL {
+                    ScrollDelta::Lines { x: 0.0, y: value }
+                } else {
+                    ScrollDelta::Lines { x: value, y: 0.0 }
+                },
+                modifiers: window_state
+                    .keyboard_state
+                    .borrow()
+                    .get_modifiers_from_mouse_wparam(wparam),
+            });
+
+            window_state.handler.borrow_mut().on_event(&mut window, event);
+
+            return Some(0);
+        }
+        WM_LBUTTONDOWN | WM_LBUTTONUP | WM_MBUTTONDOWN | WM_MBUTTONUP | WM_RBUTTONDOWN
+        | WM_RBUTTONUP | WM_XBUTTONDOWN | WM_XBUTTONUP => {
+            let mut window = window_state.create_window(hwnd);
+            let mut window = crate::Window::new(&mut window);
+
+            let mut mouse_button_counter = window_state.mouse_button_counter.get();
+
+            let button = match msg {
+                WM_LBUTTONDOWN | WM_LBUTTONUP => Some(MouseButton::Left),
+                WM_MBUTTONDOWN | WM_MBUTTONUP => Some(MouseButton::Middle),
+                WM_RBUTTONDOWN | WM_RBUTTONUP => Some(MouseButton::Right),
+                WM_XBUTTONDOWN | WM_XBUTTONUP => match GET_XBUTTON_WPARAM(wparam) {
+                    XBUTTON1 => Some(MouseButton::Back),
+                    XBUTTON2 => Some(MouseButton::Forward),
+                    _ => None,
+                },
+                _ => None,
+            };
+
+            if let Some(button) = button {
+                let event = match msg {
+                    WM_LBUTTONDOWN | WM_MBUTTONDOWN | WM_RBUTTONDOWN | WM_XBUTTONDOWN => {
+                        // Capture the mouse cursor on button down
+                        mouse_button_counter = mouse_button_counter.saturating_add(1);
+                        SetCapture(hwnd);
+                        MouseEvent::ButtonPressed {
+                            button,
+                            modifiers: window_state
+                                .keyboard_state
+                                .borrow()
+                                .get_modifiers_from_mouse_wparam(wparam),
+                        }
+                    }
+                    WM_LBUTTONUP | WM_MBUTTONUP | WM_RBUTTONUP | WM_XBUTTONUP => {
+                        // Release the mouse cursor capture when all buttons are released
+                        mouse_button_counter = mouse_button_counter.saturating_sub(1);
+                        if mouse_button_counter == 0 {
+                            ReleaseCapture();
+                        }
+
+                        MouseEvent::ButtonReleased {
+                            button,
+                            modifiers: window_state
+                                .keyboard_state
+                                .borrow()
+                                .get_modifiers_from_mouse_wparam(wparam),
+                        }
+                    }
+                    _ => {
+                        unreachable!()
+                    }
+                };
+
+                window_state.mouse_button_counter.set(mouse_button_counter);
+
+                window_state.handler.borrow_mut().on_event(&mut window, Event::Mouse(event));
+            }
+        }
+        WM_TIMER => {
+            let mut window = window_state.create_window(hwnd);
+            let mut window = crate::Window::new(&mut window);
+
+            if wparam == WIN_FRAME_TIMER {
+                window_state.handler.borrow_mut().on_frame(&mut window);
+            }
+            return Some(0);
+        }
+        WM_CLOSE => {
+            // Make sure to release the borrow before the DefWindowProc call
+            {
+                let mut window = window_state.create_window(hwnd);
+                let mut window = crate::Window::new(&mut window);
+
+                window_state
+                    .handler
+                    .borrow_mut()
+                    .on_event(&mut window, Event::Window(WindowEvent::WillClose));
+            }
+
+            // DestroyWindow(hwnd);
+            // return Some(0);
+            return Some(DefWindowProcW(hwnd, msg, wparam, lparam));
+        }
+        WM_CHAR | WM_SYSCHAR | WM_KEYDOWN | WM_SYSKEYDOWN | WM_KEYUP | WM_SYSKEYUP
+        | WM_INPUTLANGCHANGE => {
+            let mut window = window_state.create_window(hwnd);
+            let mut window = crate::Window::new(&mut window);
+
+            let opt_event =
+                window_state.keyboard_state.borrow_mut().process_message(hwnd, msg, wparam, lparam);
+
+            if let Some(event) = opt_event {
+                window_state.handler.borrow_mut().on_event(&mut window, Event::Keyboard(event));
+            }
+
+            if msg != WM_SYSKEYDOWN {
+                return Some(0);
+            }
+        }
+        WM_SIZE => {
+            let mut window = window_state.create_window(hwnd);
+            let mut window = crate::Window::new(&mut window);
+
+            let width = (lparam & 0xFFFF) as u16 as u32;
+            let height = ((lparam >> 16) & 0xFFFF) as u16 as u32;
+
+            let window_info = {
+                let mut window_info = window_state.window_info.borrow_mut();
+                *window_info =
+                    WindowInfo::from_physical_size(PhySize { width, height }, window_info.scale());
+
+                *window_info
+            };
+
+            window_state
+                .handler
+                .borrow_mut()
+                .on_event(&mut window, Event::Window(WindowEvent::Resized(window_info)));
+        }
+        WM_DPICHANGED => {
+            // To avoid weirdness with the realtime borrow checker.
+            let new_rect = {
+                if let WindowScalePolicy::SystemScaleFactor = window_state.scale_policy {
+                    let dpi = (wparam & 0xFFFF) as u16 as u32;
+                    let scale_factor = dpi as f64 / 96.0;
+
+                    let mut window_info = window_state.window_info.borrow_mut();
+                    *window_info =
+                        WindowInfo::from_logical_size(window_info.logical_size(), scale_factor);
+
+                    Some((
+                        RECT {
+                            left: 0,
+                            top: 0,
+                            // todo: check if usize fits into i32
+                            right: window_info.physical_size().width as i32,
+                            bottom: window_info.physical_size().height as i32,
+                        },
+                        window_state.dw_style,
+                    ))
+                } else {
+                    None
+                }
+            };
+            if let Some((mut new_rect, dw_style)) = new_rect {
+                // Convert this desired "client rectangle" size to the actual "window rectangle"
+                // size (Because of course you have to do that).
+                AdjustWindowRectEx(&mut new_rect, dw_style, 0, 0);
+
+                // Windows makes us resize the window manually. This will trigger another `WM_SIZE` event,
+                // which we can then send the user the new scale factor.
+                SetWindowPos(
+                    hwnd,
+                    hwnd,
+                    new_rect.left as i32,
+                    new_rect.top as i32,
+                    new_rect.right - new_rect.left,
+                    new_rect.bottom - new_rect.top,
+                    SWP_NOZORDER | SWP_NOMOVE,
+                );
+            }
+        }
+        WM_NCDESTROY => {
+            unregister_wnd_class(window_state.window_class);
+            SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);
+        }
+        _ => {
+            if msg == BV_WINDOW_MUST_CLOSE {
+                DestroyWindow(hwnd);
+                return Some(0);
+            }
+        }
+    }
+
+    None
 }
 
 unsafe fn register_wnd_class() -> ATOM {
@@ -390,6 +418,7 @@ unsafe fn unregister_wnd_class(wnd_class: ATOM) {
 /// `handler` from indirectly triggering other events that would also need to be handled using
 /// `handler`.
 struct WindowState {
+    hwnd: HWND,
     window_class: ATOM,
     window_info: RefCell<WindowInfo>,
     _parent_handle: Option<ParentHandle>,
@@ -399,6 +428,13 @@ struct WindowState {
     scale_policy: WindowScalePolicy,
     dw_style: u32,
 
+    /// Tasks that should be executed at the end of `wnd_proc`. This is needed to avoid mutably
+    /// borrowing the fields from `WindowState` more than once. For instance, when the window
+    /// handler requests a resize in response to a keyboard event, the window state will already be
+    /// borrowed in `wnd_proc`. So the `resize()` function below cannot also mutably borrow that
+    /// window state at the same time.
+    deferred_tasks: Rc<RefCell<VecDeque<WindowTask>>>,
+
     #[cfg(feature = "opengl")]
     gl_context: Rc<Option<GlContext>>,
 }
@@ -406,17 +442,63 @@ struct WindowState {
 impl WindowState {
     #[cfg(not(feature = "opengl"))]
     fn create_window(&self, hwnd: HWND) -> Window {
-        Window { hwnd }
+        Window { hwnd, deferred_tasks: self.deferred_tasks.clone() }
     }
 
     #[cfg(feature = "opengl")]
     fn create_window(&self, hwnd: HWND) -> Window {
-        Window { hwnd, gl_context: self.gl_context.clone() }
+        Window {
+            hwnd,
+            deferred_tasks: self.deferred_tasks.clone(),
+            gl_context: self.gl_context.clone(),
+        }
+    }
+
+    /// Handle a deferred task as described in [`Self::deferred_tasks
+    pub(self) fn handle_deferred_task(&self, task: WindowTask) {
+        match task {
+            WindowTask::Resize(size) => {
+                let window_info = {
+                    let mut window_info = self.window_info.borrow_mut();
+                    let scaling = window_info.scale();
+                    *window_info = WindowInfo::from_logical_size(size, scaling);
+
+                    *window_info
+                };
+
+                unsafe {
+                    SetWindowPos(
+                        self.hwnd,
+                        self.hwnd,
+                        0,
+                        0,
+                        window_info.physical_size().width as i32,
+                        window_info.physical_size().height as i32,
+                        SWP_NOZORDER | SWP_NOMOVE,
+                    )
+                };
+            }
+        }
     }
 }
 
+/// Tasks that must be deferred until the end of [`wnd_proc()`] to avoid reentrant `WindowState`
+/// borrows. See the docstring on [`WindowState::deferred_tasks`] for more information.
+#[derive(Debug, Clone)]
+enum WindowTask {
+    /// Resize the window to the given size. The size is in logical pixels. DPI scaling is applied
+    /// automatically.
+    Resize(Size),
+}
+
 pub struct Window {
+    /// The HWND belonging to this window. The window's actual state is stored in the `WindowState`
+    /// struct associated with this HWND through `unsafe { GetWindowLongPtrW(self.hwnd,
+    /// GWLP_USERDATA) } as *const WindowState`.
     hwnd: HWND,
+
+    /// See [`WindowState::deferred_tasks`].
+    deferred_tasks: Rc<RefCell<VecDeque<WindowTask>>>,
 
     #[cfg(feature = "opengl")]
     gl_context: Rc<Option<GlContext>>,
@@ -546,11 +628,20 @@ impl Window {
                 GlContext::create(&handle, gl_config).expect("Could not create OpenGL context")
             }));
 
+            // The build closure shouldn't be enqueueing deferred tasks yet, but we'll try handling
+            // them just in case to avoid losing them
+            let deferred_tasks: Rc<RefCell<VecDeque<WindowTask>>> =
+                Rc::new(RefCell::new(VecDeque::new()));
+
             #[cfg(not(feature = "opengl"))]
-            let handler = build(&mut crate::Window::new(&mut Window { hwnd }));
+            let handler = build(&mut crate::Window::new(&mut Window {
+                hwnd,
+                deferred_tasks: deferred_tasks.clone(),
+            }));
             #[cfg(feature = "opengl")]
             let handler = build(&mut crate::Window::new(&mut Window {
                 hwnd,
+                deferred_tasks: deferred_tasks.clone(),
                 gl_context: gl_context.clone(),
             }));
             let handler = RefCell::new(Box::new(handler));
@@ -559,6 +650,7 @@ impl Window {
             let parent_handle = if parented { Some(parent_handle) } else { None };
 
             let window_state = Box::new(WindowState {
+                hwnd,
                 window_class,
                 window_info: RefCell::new(window_info),
                 _parent_handle: parent_handle,
@@ -568,9 +660,17 @@ impl Window {
                 scale_policy: options.scale,
                 dw_style: flags,
 
+                deferred_tasks: Rc::new(RefCell::new(VecDeque::with_capacity(4))),
+
                 #[cfg(feature = "opengl")]
                 gl_context,
             });
+
+            // If the plugin did queue up tasks as part of the build handler, then we'll process
+            // them now
+            for task in deferred_tasks.borrow_mut().drain(..) {
+                window_state.handle_deferred_task(task);
+            }
 
             // Only works on Windows 10 unfortunately.
             SetProcessDpiAwarenessContext(
@@ -631,6 +731,13 @@ impl Window {
         unsafe {
             PostMessageW(self.hwnd, BV_WINDOW_MUST_CLOSE, 0, 0);
         }
+    }
+
+    pub fn resize(&mut self, size: Size) {
+        // To avoid reentrant event handler calls we'll defer the actual resizing until after the
+        // event has been handled
+        let task = WindowTask::Resize(size);
+        self.deferred_tasks.borrow_mut().push_back(task);
     }
 
     #[cfg(feature = "opengl")]

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -489,14 +489,23 @@ impl WindowState {
                     *window_info
                 };
 
+                // If the window is a standalone window then the size needs to include the window
+                // decorations
+                let mut rect = RECT {
+                    left: 0,
+                    top: 0,
+                    right: window_info.physical_size().width as i32,
+                    bottom: window_info.physical_size().height as i32,
+                };
                 unsafe {
+                    AdjustWindowRectEx(&mut rect, self.dw_style, 0, 0);
                     SetWindowPos(
                         self.hwnd,
                         self.hwnd,
                         0,
                         0,
-                        window_info.physical_size().width as i32,
-                        window_info.physical_size().height as i32,
+                        rect.right - rect.left,
+                        rect.bottom - rect.top,
                         SWP_NOZORDER | SWP_NOMOVE,
                     )
                 };

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -369,8 +369,8 @@ unsafe fn wnd_proc_inner(
                 SetWindowPos(
                     hwnd,
                     hwnd,
-                    new_rect.left as i32,
-                    new_rect.top as i32,
+                    new_rect.left,
+                    new_rect.top,
                     new_rect.right - new_rect.left,
                     new_rect.bottom - new_rect.top,
                     SWP_NOZORDER | SWP_NOMOVE,
@@ -721,8 +721,8 @@ impl Window {
                 SetWindowPos(
                     hwnd,
                     hwnd,
-                    new_rect.left as i32,
-                    new_rect.top as i32,
+                    new_rect.left,
+                    new_rect.top,
                     new_rect.right - new_rect.left,
                     new_rect.bottom - new_rect.top,
                     SWP_NOZORDER | SWP_NOMOVE,

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,6 +4,7 @@ use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 
 use crate::event::{Event, EventStatus};
 use crate::window_open_options::WindowOpenOptions;
+use crate::Size;
 
 #[cfg(target_os = "macos")]
 use crate::macos as platform;
@@ -96,6 +97,16 @@ impl<'a> Window<'a> {
     /// Close the window
     pub fn close(&mut self) {
         self.window.close();
+    }
+
+    /// Resize the window to the given size.
+    ///
+    /// # TODO
+    ///
+    /// This is currently only supported on Linux.
+    #[cfg(target_os = "linux")]
+    pub fn resize(&mut self, size: Size) {
+        self.window.resize(size);
     }
 
     /// If provided, then an OpenGL context will be created for this window. You'll be able to

--- a/src/window.rs
+++ b/src/window.rs
@@ -99,12 +99,9 @@ impl<'a> Window<'a> {
         self.window.close();
     }
 
-    /// Resize the window to the given size.
-    ///
-    /// # TODO
-    ///
-    /// This is currently only supported on Linux.
-    #[cfg(target_os = "linux")]
+    /// Resize the window to the given size. The size is always in logical pixels. DPI scaling will
+    /// automatically be accounted for.
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     pub fn resize(&mut self, size: Size) {
         self.window.resize(size);
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -54,12 +54,22 @@ pub trait WindowHandler {
 }
 
 pub struct Window<'a> {
+    #[cfg(target_os = "windows")]
+    window: &'a mut platform::Window<'a>,
+    #[cfg(not(target_os = "windows"))]
     window: &'a mut platform::Window,
+
     // so that Window is !Send on all platforms
     phantom: PhantomData<*mut ()>,
 }
 
 impl<'a> Window<'a> {
+    #[cfg(target_os = "windows")]
+    pub(crate) fn new(window: &'a mut platform::Window<'a>) -> Window<'a> {
+        Window { window, phantom: PhantomData }
+    }
+
+    #[cfg(not(target_os = "windows"))]
     pub(crate) fn new(window: &mut platform::Window) -> Window {
         Window { window, phantom: PhantomData }
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -101,7 +101,6 @@ impl<'a> Window<'a> {
 
     /// Resize the window to the given size. The size is always in logical pixels. DPI scaling will
     /// automatically be accounted for.
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
     pub fn resize(&mut self, size: Size) {
         self.window.resize(size);
     }

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -12,7 +12,7 @@ use xcb::StructPtr;
 
 use super::XcbConnection;
 use crate::{
-    Event, MouseButton, MouseCursor, MouseEvent, PhyPoint, PhySize, ScrollDelta, WindowEvent,
+    Event, MouseButton, MouseCursor, MouseEvent, PhyPoint, PhySize, ScrollDelta, Size, WindowEvent,
     WindowHandler, WindowInfo, WindowOpenOptions, WindowScalePolicy,
 };
 
@@ -387,6 +387,18 @@ impl Window {
 
     pub fn close(&mut self) {
         self.close_requested = true;
+    }
+
+    pub fn resize(&mut self, size: Size) {
+        xcb::configure_window(
+            &self.xcb_connection.conn,
+            self.window_id,
+            &[
+                (xcb::CONFIG_WINDOW_WIDTH as u16, size.width.round() as u32),
+                (xcb::CONFIG_WINDOW_HEIGHT as u16, size.height.round() as u32),
+            ],
+        );
+        self.xcb_connection.conn.flush();
     }
 
     #[cfg(feature = "opengl")]

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -390,12 +390,15 @@ impl Window {
     }
 
     pub fn resize(&mut self, size: Size) {
+        let scaling = self.window_info.scale();
+        self.window_info = WindowInfo::from_logical_size(size, scaling);
+
         xcb::configure_window(
             &self.xcb_connection.conn,
             self.window_id,
             &[
-                (xcb::CONFIG_WINDOW_WIDTH as u16, size.width.round() as u32),
-                (xcb::CONFIG_WINDOW_HEIGHT as u16, size.height.round() as u32),
+                (xcb::CONFIG_WINDOW_WIDTH as u16, self.window_info.physical_size().width),
+                (xcb::CONFIG_WINDOW_HEIGHT as u16, self.window_info.physical_size().height),
             ],
         );
         self.xcb_connection.conn.flush();

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -391,17 +391,20 @@ impl Window {
 
     pub fn resize(&mut self, size: Size) {
         let scaling = self.window_info.scale();
-        self.window_info = WindowInfo::from_logical_size(size, scaling);
+        let new_window_info = WindowInfo::from_logical_size(size, scaling);
 
         xcb::configure_window(
             &self.xcb_connection.conn,
             self.window_id,
             &[
-                (xcb::CONFIG_WINDOW_WIDTH as u16, self.window_info.physical_size().width),
-                (xcb::CONFIG_WINDOW_HEIGHT as u16, self.window_info.physical_size().height),
+                (xcb::CONFIG_WINDOW_WIDTH as u16, new_window_info.physical_size().width),
+                (xcb::CONFIG_WINDOW_HEIGHT as u16, new_window_info.physical_size().height),
             ],
         );
         self.xcb_connection.conn.flush();
+
+        // This will trigger a `ConfigureNotify` event which will in turn change `self.window_info`
+        // and notify the window handler about it
     }
 
     #[cfg(feature = "opengl")]


### PR DESCRIPTION
I've implemented this for Linux back in March, and I only just added Windows support. Still need to add macOS support, but I thought I'd submit a draft PR already because the changes needed for Windows support are pretty invasive. So we may want to discuss the best course of action first.

Resizing the window sends a `WM_SIZE` event and a couple other events to the window, so the window procedure and `WindowState` had to be changed to use interior mutability everywhere instead of wrapping the entire struct in a `RefCell`. This resolves most of the reentrant event call concerns from #130, but I'm not sure if it also prevents panics in that specific example  To make this work there's now a `deferred_tasks` queue for handling tasks that are the result of a call to one of the `Window` methods in an event handler that may also indirectly emit other events. Perhaps `Window::close()` should also be implemented this way.

The Linux implementation was extremely straightforward, and I'll get to the macOS one next.

This closes #121.