### PR TITLE
Allow freeing NSView based on parent window closing notifications.

### DIFF
--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -138,6 +138,10 @@ unsafe fn create_view_class() -> &'static Class {
         view_will_move_to_window as extern "C" fn(&Object, Sel, id),
     );
     class.add_method(
+        sel!(parentWindowClosing:),
+        parent_window_closing as extern "C" fn(&mut Object, Sel, id),
+    );
+    class.add_method(
         sel!(updateTrackingAreas:),
         update_tracking_areas as extern "C" fn(&Object, Sel, id),
     );
@@ -214,6 +218,16 @@ extern "C" fn release(this: &mut Object, _sel: Sel) {
     unsafe {
         let superclass = msg_send![this, superclass];
         let () = msg_send![super(this, superclass), release];
+    }
+}
+
+extern "C" fn parent_window_closing(this: &mut Object, _sel: Sel, _: id) {
+    unsafe {
+        let state_ptr: *mut c_void = *this.get_ivar(BASEVIEW_STATE_IVAR);
+
+        if !state_ptr.is_null() {
+            WindowState::stop_and_free(this);
+        }
     }
 }
 


### PR DESCRIPTION
In order to use third party crates that, under the hood, may increase the ref count of the given `NSView`, we add an additional "window closing" check by querying the given `NSView` for its `NSWindow` parent, and subscribing to the `NSWindowWillCloseNotification` message.

Note that in DAWs such as Reaper, we share a parent window with other plugins, so this approach is not reliable (since you can switch between different plugins but the window persists). Those cases may require another solution.

(Mostly) fixes #124