### PR TITLE
bump raw_window_handle to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ opengl = ["uuid", "x11/glx"]
 
 [dependencies]
 keyboard-types = { version = "0.6.1", default-features = false }
-raw-window-handle = "0.4.2"
+raw-window-handle = "0.5.0"
 
 [target.'cfg(target_os="linux")'.dependencies]
 xcb = { version = "0.9", features = ["thread", "xlib_xcb", "dri2"] }

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -17,7 +17,9 @@ use keyboard_types::KeyboardEvent;
 
 use objc::{msg_send, runtime::Object, sel, sel_impl};
 
-use raw_window_handle::{AppKitHandle, HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{AppKitWindowHandle, AppKitDisplayHandle};
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasRawDisplayHandle, RawDisplayHandle};
 
 use crate::{
     Event, EventStatus, WindowEvent, WindowHandler, WindowInfo, WindowOpenOptions,
@@ -62,7 +64,7 @@ unsafe impl HasRawWindowHandle for WindowHandle {
             }
         }
 
-        RawWindowHandle::AppKit(AppKitHandle::empty())
+        RawWindowHandle::AppKit(AppKitWindowHandle::empty())
     }
 }
 
@@ -309,7 +311,7 @@ impl Window {
 
     #[cfg(feature = "opengl")]
     fn create_gl_context(ns_window: Option<id>, ns_view: id, config: GlConfig) -> GlContext {
-        let mut handle = AppKitHandle::empty();
+        let mut handle = AppKitWindowHandle::empty();
         handle.ns_window = ns_window.unwrap_or(ptr::null_mut()) as *mut c_void;
         handle.ns_view = ns_view as *mut c_void;
         let handle = RawWindowHandleWrapper { handle: RawWindowHandle::AppKit(handle) };
@@ -438,10 +440,23 @@ unsafe impl HasRawWindowHandle for Window {
     fn raw_window_handle(&self) -> RawWindowHandle {
         let ns_window = self.ns_window.unwrap_or(ptr::null_mut()) as *mut c_void;
 
-        let mut handle = AppKitHandle::empty();
+        let mut handle = AppKitWindowHandle::empty();
         handle.ns_window = ns_window;
         handle.ns_view = self.ns_view as *mut c_void;
 
         RawWindowHandle::AppKit(handle)
     }
+}
+
+unsafe impl HasRawDisplayHandle for Window {
+    fn raw_display_handle(&self) -> RawDisplayHandle {
+        // let ns_window = self.ns_window.unwrap_or(ptr::null_mut()) as *mut c_void;
+
+        let mut handle = AppKitDisplayHandle::empty();
+        // handle.ns_window = ns_window;
+        // handle.ns_view = self.ns_view as *mut c_void;
+
+        RawDisplayHandle::AppKit(handle)
+    }
+
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasRawDisplayHandle, RawDisplayHandle};
 
 use crate::event::{Event, EventStatus};
 use crate::window_open_options::WindowOpenOptions;
@@ -22,6 +23,10 @@ pub struct WindowHandle {
 /// have a raw window handle, that would be silly.
 pub(crate) struct RawWindowHandleWrapper {
     pub handle: RawWindowHandle,
+}
+
+pub(crate) struct RawDisplayHandleWrapper {
+    pub handle: RawDisplayHandle,
 }
 
 impl WindowHandle {
@@ -114,6 +119,18 @@ unsafe impl<'a> HasRawWindowHandle for Window<'a> {
 
 unsafe impl HasRawWindowHandle for RawWindowHandleWrapper {
     fn raw_window_handle(&self) -> RawWindowHandle {
+        self.handle
+    }
+}
+
+unsafe impl<'a> HasRawDisplayHandle for Window<'a> {
+    fn raw_display_handle(&self) -> RawDisplayHandle {
+        self.window.raw_display_handle()
+    }
+}
+
+unsafe impl HasRawDisplayHandle for RawDisplayHandleWrapper {
+    fn raw_display_handle(&self) -> RawDisplayHandle {
         self.handle
     }
 }


### PR DESCRIPTION
hi! i made some changes so that raw_window_handle can be updated to 0.5.0 (this because im using it in conjunction with [softbuffer](https://github.com/rust-windowing/softbuffer) for a personal project).

i only made the changes necessary for this pull request to work on macos since i don't have any access to another machine/os at the moment, but i'll leave this pr here in case there's initiative to update raw_window_handle in the future.