### PR TITLE
Windows: Add public defer method

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -115,6 +115,14 @@ impl<'a> Window<'a> {
         self.window.resize(size);
     }
 
+    /// Defers execution of the given task until the end of main loop cycle.
+    ///
+    /// This is sometimes necessary to avoid mutably borrowing internal fields more than once.
+    #[cfg(windows)]
+    pub fn defer(&mut self, task: impl Fn() + 'static) {
+        self.window.defer(task);
+    }
+
     /// If provided, then an OpenGL context will be created for this window. You'll be able to
     /// access this context through [crate::Window::gl_context].
     #[cfg(feature = "opengl")]


### PR DESCRIPTION
This solves #143 in a better way than #130 did. It lets downstream crates defer tasks until the end of the current main loop cycle in order to prevent "already borrowed" errors because of multiple mutable borrows of the window state.

I added this method for Windows only because this is the only OS where baseview uses RefCells and the only OS for which the `deferred_task` queue has been implemented (in #136).