### PR TITLE
Add logic for CursorEntered/CursorLeft on x11

### DIFF
--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -280,10 +280,12 @@ impl Window {
                         | xcb::EVENT_MASK_BUTTON_RELEASE
                         | xcb::EVENT_MASK_KEY_PRESS
                         | xcb::EVENT_MASK_KEY_RELEASE
-                        | xcb::EVENT_MASK_STRUCTURE_NOTIFY,
+                        | xcb::EVENT_MASK_STRUCTURE_NOTIFY
+                        | xcb::EVENT_MASK_ENTER_WINDOW
+                        | xcb::EVENT_MASK_LEAVE_WINDOW,
                 ),
-                // As mentioend above, these two values are needed to be able to create a window
-                // with a dpeth of 32-bits when the parent window has a different depth
+                // As mentioned above, these two values are needed to be able to create a window
+                // with a depth of 32-bits when the parent window has a different depth
                 (xcb::CW_COLORMAP, colormap),
                 (xcb::CW_BORDER_PIXEL, 0),
             ],
@@ -607,6 +609,20 @@ impl Window {
                         }),
                     );
                 }
+            }
+
+            // mouse entering the window
+            // TODO: might need to consider the window used in `xcb::cast_event::<xcb::MotionNotifyEvent>(&event)`
+            xcb::ENTER_NOTIFY => {
+                handler.on_event(
+                    &mut crate::Window::new(self),
+                    Event::Mouse(MouseEvent::CursorEntered),
+                );
+            }
+
+            xcb::LEAVE_NOTIFY => {
+                handler
+                    .on_event(&mut crate::Window::new(self), Event::Mouse(MouseEvent::CursorLeft));
             }
 
             xcb::BUTTON_PRESS => {


### PR DESCRIPTION
Necessary to fix https://github.com/vizia/vizia/issues/407, which is a bug that locks up the GUI when you press down on a mouse button inside the window and release the button outside the window.