### PR TITLE
Remove Window::open_as_if_parented

### DIFF
--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -166,44 +166,6 @@ impl Window {
         window_handle
     }
 
-    pub fn open_as_if_parented<H, B>(options: WindowOpenOptions, build: B) -> WindowHandle
-    where
-        H: WindowHandler + 'static,
-        B: FnOnce(&mut crate::Window) -> H,
-        B: Send + 'static,
-    {
-        let pool = unsafe { NSAutoreleasePool::new(nil) };
-
-        let scaling = match options.scale {
-            WindowScalePolicy::ScaleFactor(scale) => scale,
-            WindowScalePolicy::SystemScaleFactor => 1.0,
-        };
-
-        let window_info = WindowInfo::from_logical_size(options.size, scaling);
-
-        let ns_view = unsafe { create_view(&options) };
-
-        let window = Window {
-            ns_app: None,
-            ns_window: None,
-            ns_view,
-            close_requested: false,
-
-            #[cfg(feature = "opengl")]
-            gl_context: options
-                .gl_config
-                .map(|gl_config| Self::create_gl_context(None, ns_view, gl_config)),
-        };
-
-        let window_handle = Self::init(true, window, window_info, build);
-
-        unsafe {
-            let () = msg_send![pool, drain];
-        }
-
-        window_handle
-    }
-
     pub fn open_blocking<H, B>(options: WindowOpenOptions, build: B)
     where
         H: WindowHandler + 'static,

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -565,17 +565,6 @@ impl Window<'_> {
         window_handle
     }
 
-    pub fn open_as_if_parented<H, B>(options: WindowOpenOptions, build: B) -> WindowHandle
-    where
-        H: WindowHandler + 'static,
-        B: FnOnce(&mut crate::Window) -> H,
-        B: Send + 'static,
-    {
-        let (window_handle, _) = Self::open(true, null_mut(), options, build);
-
-        window_handle
-    }
-
     pub fn open_blocking<H, B>(options: WindowOpenOptions, build: B)
     where
         H: WindowHandler + 'static,

--- a/src/window.rs
+++ b/src/window.rs
@@ -87,16 +87,6 @@ impl<'a> Window<'a> {
         WindowHandle::new(window_handle)
     }
 
-    pub fn open_as_if_parented<H, B>(options: WindowOpenOptions, build: B) -> WindowHandle
-    where
-        H: WindowHandler + 'static,
-        B: FnOnce(&mut Window) -> H,
-        B: Send + 'static,
-    {
-        let window_handle = platform::Window::open_as_if_parented::<H, B>(options, build);
-        WindowHandle::new(window_handle)
-    }
-
     pub fn open_blocking<H, B>(options: WindowOpenOptions, build: B)
     where
         H: WindowHandler + 'static,

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -147,26 +147,6 @@ impl Window {
         window_handle
     }
 
-    pub fn open_as_if_parented<H, B>(options: WindowOpenOptions, build: B) -> WindowHandle
-    where
-        H: WindowHandler + 'static,
-        B: FnOnce(&mut crate::Window) -> H,
-        B: Send + 'static,
-    {
-        let (tx, rx) = mpsc::sync_channel::<WindowOpenResult>(1);
-
-        let (parent_handle, mut window_handle) = ParentHandle::new();
-
-        thread::spawn(move || {
-            Self::window_thread(None, options, build, tx.clone(), Some(parent_handle));
-        });
-
-        let raw_window_handle = rx.recv().unwrap().unwrap();
-        window_handle.raw_window_handle = Some(raw_window_handle.0);
-
-        window_handle
-    }
-
     pub fn open_blocking<H, B>(options: WindowOpenOptions, build: B)
     where
         H: WindowHandler + 'static,


### PR DESCRIPTION
The open_as_if_parented method was intended to support the use case of Audio Unit plugin views. However, the Audio Unit API differs in important ways from other plugin APIs (such as VST 3 and CLAP) with regard to the lifetime management of the plugin's NSView, and trying to support both lifetime management patterns simultaneously has been the source of complexity and bugs. Thus, rather than implementing Audio Unit NSView management directly in Baseview, it will be the responsibility of plugin frameworks to implement a compatibility layer between the Audio Unit API and the Baseview API.