### PR TITLE
Remove RawWindowHandleWrapper

### DIFF
--- a/src/gl/macos.rs
+++ b/src/gl/macos.rs
@@ -1,7 +1,7 @@
 use std::ffi::c_void;
 use std::str::FromStr;
 
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::RawWindowHandle;
 
 use cocoa::appkit::{
     NSOpenGLContext, NSOpenGLContextParameter, NSOpenGLPFAAccelerated, NSOpenGLPFAAlphaSize,
@@ -28,10 +28,8 @@ pub struct GlContext {
 }
 
 impl GlContext {
-    pub unsafe fn create(
-        parent: &impl HasRawWindowHandle, config: GlConfig,
-    ) -> Result<GlContext, GlError> {
-        let handle = if let RawWindowHandle::AppKit(handle) = parent.raw_window_handle() {
+    pub unsafe fn create(parent: &RawWindowHandle, config: GlConfig) -> Result<GlContext, GlError> {
+        let handle = if let RawWindowHandle::AppKit(handle) = parent {
             handle
         } else {
             return Err(GlError::InvalidWindowHandle);

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 // On X11 creating the context is a two step process
 #[cfg(not(target_os = "linux"))]
-use raw_window_handle::HasRawWindowHandle;
+use raw_window_handle::RawWindowHandle;
 
 #[cfg(target_os = "windows")]
 mod win;
@@ -77,7 +77,7 @@ pub struct GlContext {
 impl GlContext {
     #[cfg(not(target_os = "linux"))]
     pub(crate) unsafe fn create(
-        parent: &impl HasRawWindowHandle, config: GlConfig,
+        parent: &RawWindowHandle, config: GlConfig,
     ) -> Result<GlContext, GlError> {
         platform::GlContext::create(parent, config)
             .map(|context| GlContext { context, phantom: PhantomData })

--- a/src/gl/win.rs
+++ b/src/gl/win.rs
@@ -1,7 +1,7 @@
 use std::ffi::{c_void, CString, OsStr};
 use std::os::windows::ffi::OsStrExt;
 
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::RawWindowHandle;
 
 use winapi::shared::minwindef::{HINSTANCE, HMODULE};
 use winapi::shared::ntdef::WCHAR;
@@ -77,10 +77,8 @@ extern "C" {
 }
 
 impl GlContext {
-    pub unsafe fn create(
-        parent: &impl HasRawWindowHandle, config: GlConfig,
-    ) -> Result<GlContext, GlError> {
-        let handle = if let RawWindowHandle::Win32(handle) = parent.raw_window_handle() {
+    pub unsafe fn create(parent: &RawWindowHandle, config: GlConfig) -> Result<GlContext, GlError> {
+        let handle = if let RawWindowHandle::Win32(handle) = parent {
             handle
         } else {
             return Err(GlError::InvalidWindowHandle);

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -31,10 +31,7 @@ use super::keyboard::KeyboardState;
 use super::view::{create_view, BASEVIEW_STATE_IVAR};
 
 #[cfg(feature = "opengl")]
-use crate::{
-    gl::{GlConfig, GlContext},
-    window::RawWindowHandleWrapper,
-};
+use crate::gl::{GlConfig, GlContext};
 
 pub struct WindowHandle {
     raw_window_handle: Option<RawWindowHandle>,
@@ -313,7 +310,7 @@ impl Window {
         let mut handle = AppKitWindowHandle::empty();
         handle.ns_window = ns_window.unwrap_or(ptr::null_mut()) as *mut c_void;
         handle.ns_view = ns_view as *mut c_void;
-        let handle = RawWindowHandleWrapper { handle: RawWindowHandle::AppKit(handle) };
+        let handle = RawWindowHandle::AppKit(handle);
 
         unsafe { GlContext::create(&handle, config).expect("Could not create OpenGL context") }
     }

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -42,7 +42,7 @@ use super::drop_target::DropTarget;
 use super::keyboard::KeyboardState;
 
 #[cfg(feature = "opengl")]
-use crate::{gl::GlContext, window::RawWindowHandleWrapper};
+use crate::gl::GlContext;
 
 unsafe fn generate_guid() -> String {
     let mut guid: GUID = std::mem::zeroed();
@@ -655,7 +655,7 @@ impl Window<'_> {
             let gl_context: Option<GlContext> = options.gl_config.map(|gl_config| {
                 let mut handle = Win32WindowHandle::empty();
                 handle.hwnd = hwnd as *mut c_void;
-                let handle = RawWindowHandleWrapper { handle: RawWindowHandle::Win32(handle) };
+                let handle = RawWindowHandle::Win32(handle);
 
                 GlContext::create(&handle, gl_config).expect("Could not create OpenGL context")
             });

--- a/src/window.rs
+++ b/src/window.rs
@@ -21,12 +21,6 @@ pub struct WindowHandle {
     phantom: PhantomData<*mut ()>,
 }
 
-/// Quick wrapper to satisfy [HasRawWindowHandle], because of course a raw window handle wouldn't
-/// have a raw window handle, that would be silly.
-pub(crate) struct RawWindowHandleWrapper {
-    pub handle: RawWindowHandle,
-}
-
 impl WindowHandle {
     fn new(window_handle: platform::WindowHandle) -> Self {
         Self { window_handle, phantom: PhantomData::default() }
@@ -124,11 +118,5 @@ unsafe impl<'a> HasRawWindowHandle for Window<'a> {
 unsafe impl<'a> HasRawDisplayHandle for Window<'a> {
     fn raw_display_handle(&self) -> RawDisplayHandle {
         self.window.raw_display_handle()
-    }
-}
-
-unsafe impl HasRawWindowHandle for RawWindowHandleWrapper {
-    fn raw_window_handle(&self) -> RawWindowHandle {
-        self.handle
     }
 }


### PR DESCRIPTION
RawWindowHandleWrapper is only necessary since GlContext::create takes an `impl HasRawWindowHandle` argument, but GlContext::create is an internal unsafe API and it can just take a RawWindowHandle directly.