### PR TITLE
Expose public Window::set_mouse_cursor method

### DIFF
--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -23,8 +23,8 @@ use raw_window_handle::{
 };
 
 use crate::{
-    Event, EventStatus, Size, WindowEvent, WindowHandler, WindowInfo, WindowOpenOptions,
-    WindowScalePolicy,
+    Event, EventStatus, MouseCursor, Size, WindowEvent, WindowHandler, WindowInfo,
+    WindowOpenOptions, WindowScalePolicy,
 };
 
 use super::keyboard::KeyboardState;
@@ -298,6 +298,10 @@ impl Window {
         if let Some(ns_window) = self.ns_window {
             unsafe { NSWindow::setContentSize_(ns_window, size) };
         }
+    }
+
+    pub fn set_mouse_cursor(&mut self, _mouse_cursor: MouseCursor) {
+        todo!()
     }
 
     #[cfg(feature = "opengl")]

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -34,7 +34,7 @@ use raw_window_handle::{
 const BV_WINDOW_MUST_CLOSE: UINT = WM_USER + 1;
 
 use crate::{
-    Event, MouseButton, MouseEvent, PhyPoint, PhySize, ScrollDelta, Size, WindowEvent,
+    Event, MouseButton, MouseCursor, MouseEvent, PhyPoint, PhySize, ScrollDelta, Size, WindowEvent,
     WindowHandler, WindowInfo, WindowOpenOptions, WindowScalePolicy,
 };
 
@@ -763,6 +763,10 @@ impl Window<'_> {
         // event has been handled
         let task = WindowTask::Resize(size);
         self.state.deferred_tasks.borrow_mut().push_back(task);
+    }
+
+    pub fn set_mouse_cursor(&mut self, _mouse_cursor: MouseCursor) {
+        todo!()
     }
 
     #[cfg(feature = "opengl")]

--- a/src/window.rs
+++ b/src/window.rs
@@ -6,7 +6,7 @@ use raw_window_handle::{
 
 use crate::event::{Event, EventStatus};
 use crate::window_open_options::WindowOpenOptions;
-use crate::Size;
+use crate::{MouseCursor, Size};
 
 #[cfg(target_os = "macos")]
 use crate::macos as platform;
@@ -99,6 +99,10 @@ impl<'a> Window<'a> {
     /// automatically be accounted for.
     pub fn resize(&mut self, size: Size) {
         self.window.resize(size);
+    }
+
+    pub fn set_mouse_cursor(&mut self, cursor: MouseCursor) {
+        self.window.set_mouse_cursor(cursor);
     }
 
     /// If provided, then an OpenGL context will be created for this window. You'll be able to

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -97,7 +97,6 @@ pub struct Window {
     window_id: u32,
     window_info: WindowInfo,
     visual_id: u32,
-    // FIXME: There's all this mouse cursor logic but it's never actually used, is this correct?
     mouse_cursor: MouseCursor,
 
     frame_interval: Duration,

--- a/src/x11/xcb_connection.rs
+++ b/src/x11/xcb_connection.rs
@@ -19,7 +19,6 @@ pub struct XcbConnection {
 
     pub(crate) atoms: Atoms,
 
-    // FIXME: Same here, there's a ton of unused cursor machinery in here
     pub(super) cursor_cache: HashMap<MouseCursor, u32>,
 }
 


### PR DESCRIPTION
The X11 backend has a full implementation of a `Window::set_mouse_cursor` method, but it isn't exposed via any public interface, which results in a lot of warnings for unused code. Add a public `set_mouse_cursor` method, along with stubbed-out versions in the Windows and macOS backends.