### PR TITLE
Remove unnecessary PhantomData fields from platform::WindowHandle definitions

### DIFF
--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -1,6 +1,5 @@
 use std::cell::{Cell, RefCell};
 use std::ffi::c_void;
-use std::marker::PhantomData;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -38,9 +37,6 @@ pub struct WindowHandle {
     raw_window_handle: Option<RawWindowHandle>,
     close_requested: Arc<AtomicBool>,
     is_open: Arc<AtomicBool>,
-
-    // Ensure handle is !Send
-    _phantom: PhantomData<*mut ()>,
 }
 
 impl WindowHandle {
@@ -81,7 +77,6 @@ impl ParentHandle {
             raw_window_handle: Some(raw_window_handle),
             close_requested: Arc::clone(&close_requested),
             is_open: Arc::clone(&is_open),
-            _phantom: PhantomData::default(),
         };
 
         (Self { _close_requested: close_requested, is_open }, handle)

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -21,7 +21,6 @@ use winapi::um::winuser::{
 use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::collections::VecDeque;
 use std::ffi::{c_void, OsStr};
-use std::marker::PhantomData;
 use std::os::windows::ffi::OsStrExt;
 use std::ptr::null_mut;
 use std::rc::Rc;
@@ -68,9 +67,6 @@ const WIN_FRAME_TIMER: usize = 4242;
 pub struct WindowHandle {
     hwnd: Option<HWND>,
     is_open: Rc<Cell<bool>>,
-
-    // Ensure handle is !Send
-    _phantom: PhantomData<*mut ()>,
 }
 
 impl WindowHandle {
@@ -108,11 +104,7 @@ impl ParentHandle {
     pub fn new(hwnd: HWND) -> (Self, WindowHandle) {
         let is_open = Rc::new(Cell::new(true));
 
-        let handle = WindowHandle {
-            hwnd: Some(hwnd),
-            is_open: Rc::clone(&is_open),
-            _phantom: PhantomData::default(),
-        };
+        let handle = WindowHandle { hwnd: Some(hwnd), is_open: Rc::clone(&is_open) };
 
         (Self { is_open }, handle)
     }

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -1,5 +1,4 @@
 use std::ffi::c_void;
-use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -28,9 +27,6 @@ pub struct WindowHandle {
     raw_window_handle: Option<RawWindowHandle>,
     close_requested: Arc<AtomicBool>,
     is_open: Arc<AtomicBool>,
-
-    // Ensure handle is !Send
-    _phantom: PhantomData<*mut ()>,
 }
 
 impl WindowHandle {
@@ -75,7 +71,6 @@ impl ParentHandle {
             raw_window_handle: None,
             close_requested: Arc::clone(&close_requested),
             is_open: Arc::clone(&is_open),
-            _phantom: PhantomData::default(),
         };
 
         (Self { close_requested, is_open }, handle)


### PR DESCRIPTION
These `PhantomData` fields are redundant, as the public `WindowHandle` struct already contains one.