### PR TITLE
Implement input focus for Mac & Windows

### DIFF
--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -281,7 +281,7 @@ impl<'a> Window<'a> {
         self.inner.close();
     }
 
-    pub fn has_input_focus(&mut self) -> bool {
+    pub fn has_focus(&mut self) -> bool {
         unsafe {
             let view = self.inner.ns_view.as_mut().unwrap();
             let window: id = msg_send![view, window];
@@ -293,7 +293,7 @@ impl<'a> Window<'a> {
         }
     }
 
-    pub fn set_input_focus(&mut self) {
+    pub fn focus(&mut self) {
         unsafe {
             let view = self.inner.ns_view.as_mut().unwrap();
             let window: id = msg_send![view, window];

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -287,8 +287,9 @@ impl<'a> Window<'a> {
             let window: id = msg_send![view, window];
             if window == nil { return false; };
             let first_responder: id = msg_send![window, firstResponder];
+            let is_key_window: BOOL = msg_send![window, isKeyWindow];
             let is_focused: BOOL = msg_send![view, isEqual: first_responder];
-            is_focused == YES
+            is_key_window == YES && is_focused == YES
         }
     }
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -297,7 +297,6 @@ impl<'a> Window<'a> {
             let view = self.inner.ns_view.as_mut().unwrap();
             let window: id = msg_send![view, window];
             if window != nil {
-                let _: () = msg_send![window, makeKeyWindow];
                 msg_send![window, makeFirstResponder:view]
             }
         }

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -771,8 +771,8 @@ impl Window<'_> {
     }
 
     pub fn has_focus(&mut self) -> bool {
-        let foreground_window = unsafe { GetFocus() };
-        foreground_window == self.state.hwnd
+        let focused_window = unsafe { GetFocus() };
+        focused_window == self.state.hwnd
     }
 
     pub fn focus(&mut self) {

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -770,6 +770,14 @@ impl Window<'_> {
         }
     }
 
+    pub fn has_input_focus(&mut self) -> bool {
+        unimplemented!()
+    }
+
+    pub fn set_input_focus(&mut self) {
+        unimplemented!()
+    }
+
     pub fn resize(&mut self, size: Size) {
         // To avoid reentrant event handler calls we'll defer the actual resizing until after the
         // event has been handled

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -770,12 +770,12 @@ impl Window<'_> {
         }
     }
 
-    pub fn has_input_focus(&mut self) -> bool {
+    pub fn has_focus(&mut self) -> bool {
         let foreground_window = unsafe { GetForegroundWindow() };
         foreground_window == self.state.hwnd
     }
 
-    pub fn set_input_focus(&mut self) {
+    pub fn focus(&mut self) {
         unsafe {
             SetFocus(self.state.hwnd);
         }

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -8,7 +8,7 @@ use winapi::um::winuser::{
     AdjustWindowRectEx, CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW,
     GetDpiForWindow, GetMessageW, GetWindowLongPtrW, LoadCursorW, PostMessageW, RegisterClassW,
     ReleaseCapture, SetCapture, SetProcessDpiAwarenessContext, SetTimer, SetWindowLongPtrW,
-    SetWindowPos, TrackMouseEvent, TranslateMessage, UnregisterClassW, CS_OWNDC,
+    SetWindowPos, SetFocus, GetForegroundWindow, TrackMouseEvent, TranslateMessage, UnregisterClassW, CS_OWNDC,
     GET_XBUTTON_WPARAM, GWLP_USERDATA, IDC_ARROW, MSG, SWP_NOMOVE, SWP_NOZORDER, TRACKMOUSEEVENT,
     WHEEL_DELTA, WM_CHAR, WM_CLOSE, WM_CREATE, WM_DPICHANGED, WM_INPUTLANGCHANGE, WM_KEYDOWN,
     WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL,
@@ -771,11 +771,14 @@ impl Window<'_> {
     }
 
     pub fn has_input_focus(&mut self) -> bool {
-        unimplemented!()
+        let foreground_window = unsafe { GetForegroundWindow() };
+        foreground_window == self.state.hwnd
     }
 
     pub fn set_input_focus(&mut self) {
-        unimplemented!()
+        unsafe {
+            SetFocus(self.state.hwnd);
+        }
     }
 
     pub fn resize(&mut self, size: Size) {

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -8,7 +8,7 @@ use winapi::um::winuser::{
     AdjustWindowRectEx, CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW,
     GetDpiForWindow, GetMessageW, GetWindowLongPtrW, LoadCursorW, PostMessageW, RegisterClassW,
     ReleaseCapture, SetCapture, SetProcessDpiAwarenessContext, SetTimer, SetWindowLongPtrW,
-    SetWindowPos, SetFocus, GetForegroundWindow, TrackMouseEvent, TranslateMessage, UnregisterClassW, CS_OWNDC,
+    SetWindowPos, SetFocus, GetFocus, TrackMouseEvent, TranslateMessage, UnregisterClassW, CS_OWNDC,
     GET_XBUTTON_WPARAM, GWLP_USERDATA, IDC_ARROW, MSG, SWP_NOMOVE, SWP_NOZORDER, TRACKMOUSEEVENT,
     WHEEL_DELTA, WM_CHAR, WM_CLOSE, WM_CREATE, WM_DPICHANGED, WM_INPUTLANGCHANGE, WM_KEYDOWN,
     WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL,
@@ -771,7 +771,7 @@ impl Window<'_> {
     }
 
     pub fn has_focus(&mut self) -> bool {
-        let foreground_window = unsafe { GetForegroundWindow() };
+        let foreground_window = unsafe { GetFocus() };
         foreground_window == self.state.hwnd
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -102,12 +102,12 @@ impl<'a> Window<'a> {
         self.window.set_mouse_cursor(cursor);
     }
 
-    pub fn has_input_focus(&mut self) -> bool {
-        self.window.has_input_focus()
+    pub fn has_focus(&mut self) -> bool {
+        self.window.has_focus()
     }
 
-    pub fn set_input_focus(&mut self) {
-        self.window.set_input_focus()
+    pub fn focus(&mut self) {
+        self.window.focus()
     }
 
     /// If provided, then an OpenGL context will be created for this window. You'll be able to

--- a/src/window.rs
+++ b/src/window.rs
@@ -102,6 +102,14 @@ impl<'a> Window<'a> {
         self.window.set_mouse_cursor(cursor);
     }
 
+    pub fn has_input_focus(&mut self) -> bool {
+        self.window.has_input_focus()
+    }
+
+    pub fn set_input_focus(&mut self) {
+        self.window.set_input_focus()
+    }
+
     /// If provided, then an OpenGL context will be created for this window. You'll be able to
     /// access this context through [crate::Window::gl_context].
     #[cfg(feature = "opengl")]

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -370,11 +370,11 @@ impl<'a> Window<'a> {
         self.inner.close_requested = true;
     }
 
-    pub fn has_input_focus(&mut self) -> bool {
+    pub fn has_focus(&mut self) -> bool {
         unimplemented!()
     }
 
-    pub fn set_input_focus(&mut self) {
+    pub fn focus(&mut self) {
         unimplemented!()
     }
 

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -370,6 +370,14 @@ impl<'a> Window<'a> {
         self.inner.close_requested = true;
     }
 
+    pub fn has_input_focus(&mut self) -> bool {
+        unimplemented!()
+    }
+
+    pub fn set_input_focus(&mut self) {
+        unimplemented!()
+    }
+
     pub fn resize(&mut self, size: Size) {
         let scaling = self.inner.window_info.scale();
         let new_window_info = WindowInfo::from_logical_size(size, scaling);


### PR DESCRIPTION
As per https://github.com/RustAudio/baseview/issues/152. Still not working for VST but that appears to be due to a separate issue (see https://github.com/RustAudio/baseview/issues/169). I tested it in a `nih_plug` CLAP plugin in Reaper. I had to modify `vizia_baseview` to call `set_input_focus` when the alt-click event is triggered. Will also commit those changes there if this is accepted as a solution.