### PR TITLE
add support for Window::Focused/Unfocused events on macOS

### DIFF
--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -218,7 +218,14 @@ extern "C" fn accepts_first_mouse(_this: &Object, _sel: Sel, _event: id) -> BOOL
 
 extern "C" fn become_first_responder(this: &Object, _sel: Sel) -> BOOL {
     let state = unsafe { WindowState::from_view(this) };
-    state.trigger_event(Event::Window(WindowEvent::Focused));
+    let is_key_window = unsafe {
+        let window: id = msg_send![state.window_inner.ns_view, window];
+        let is_key_window: BOOL = msg_send![window, isKeyWindow];
+        is_key_window == YES
+    };
+    if is_key_window {
+        state.trigger_event(Event::Window(WindowEvent::Focused));
+    }
     YES
 }
 

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -124,6 +124,14 @@ unsafe fn create_view_class() -> &'static Class {
         sel!(acceptsFirstResponder),
         property_yes as extern "C" fn(&Object, Sel) -> BOOL,
     );
+    class.add_method(
+        sel!(becomeFirstResponder),
+        become_first_responder as extern "C" fn(&Object, Sel) -> BOOL,
+    );
+    class.add_method(
+        sel!(resignFirstResponder),
+        resign_first_responder as extern "C" fn(&Object, Sel) -> BOOL,
+    );
     class.add_method(sel!(isFlipped), property_yes as extern "C" fn(&Object, Sel) -> BOOL);
     class.add_method(
         sel!(preservesContentInLiveResize),
@@ -205,6 +213,18 @@ extern "C" fn property_no(_this: &Object, _sel: Sel) -> BOOL {
 }
 
 extern "C" fn accepts_first_mouse(_this: &Object, _sel: Sel, _event: id) -> BOOL {
+    YES
+}
+
+extern "C" fn become_first_responder(this: &Object, _sel: Sel) -> BOOL {
+    let state = unsafe { WindowState::from_view(this) };
+    state.trigger_event(Event::Window(WindowEvent::Focused));
+    YES
+}
+
+extern "C" fn resign_first_responder(this: &Object, _sel: Sel) -> BOOL {
+    let state = unsafe { WindowState::from_view(this) };
+    state.trigger_event(Event::Window(WindowEvent::Unfocused));
     YES
 }
 

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -468,8 +468,6 @@ impl NSWindowNotificationObserver {
             };
 
             let notification_center: id = msg_send![class!(NSNotificationCenter), defaultCenter];
-
-            let window: id = msg_send![window_state.window_inner.ns_view, window];
             let window_state_ptr = Rc::into_raw(Rc::clone(&window_state));
 
             (*observer).set_ivar(BASEVIEW_STATE_IVAR, window_state_ptr as *const c_void);
@@ -479,7 +477,7 @@ impl NSWindowNotificationObserver {
                 addObserver:observer
                 selector:sel!(handleNotification:)
                 name:NSString::alloc(nil).init_str(Self::NS_WINDOW_DID_BECOME_KEY_NOTIFICATION)
-                object:window
+                object:nil
             ];
 
             let _: () = msg_send![
@@ -487,7 +485,7 @@ impl NSWindowNotificationObserver {
                 addObserver:observer
                 selector:sel!(handleNotification:)
                 name:NSString::alloc(nil).init_str(Self::NS_WINDOW_DID_RESIGN_KEY_NOTIFICATION)
-                object:window
+                object:nil
             ];
 
             Self { observer }

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -68,7 +68,7 @@ pub(super) struct WindowInner {
     /// parentless mode
     ns_window: Cell<Option<id>>,
     /// Our subclassed NSView
-    ns_view: id,
+    pub(crate) ns_view: id,
 
     #[cfg(feature = "opengl")]
     gl_context: Option<GlContext>,


### PR DESCRIPTION
trigger `WindowEvent::Focused` and `WindowEvent::Unfocused` events when the plugin window gains/loses focus. implemented by adding observers to `NSNotificationCenter::defaultCenter()` that listen to `NSWindowDidBecomeKeyNotification` and `NSWindowDidResignKeyNotification` notifications on the `NSViews`' window.

tested and confirmed to work in Live, Bitwig, FL Studio, Reaper and AudioPluginHost.