### PR TITLE
Render a background for the open_window example

### DIFF
--- a/examples/open_window.rs
+++ b/examples/open_window.rs
@@ -1,10 +1,13 @@
+use std::num::NonZeroU32;
 use std::time::Duration;
 
 use rtrb::{Consumer, RingBuffer};
 
 #[cfg(target_os = "macos")]
 use baseview::copy_to_clipboard;
-use baseview::{Event, EventStatus, MouseEvent, Window, WindowHandler, WindowScalePolicy};
+use baseview::{
+    Event, EventStatus, MouseEvent, PhySize, Window, WindowEvent, WindowHandler, WindowScalePolicy,
+};
 
 #[derive(Debug, Clone)]
 enum Message {
@@ -13,10 +16,22 @@ enum Message {
 
 struct OpenWindowExample {
     rx: Consumer<Message>,
+
+    ctx: softbuffer::Context,
+    surface: softbuffer::Surface,
+    current_size: PhySize,
+    damaged: bool,
 }
 
 impl WindowHandler for OpenWindowExample {
     fn on_frame(&mut self, _window: &mut Window) {
+        let mut buf = self.surface.buffer_mut().unwrap();
+        if self.damaged {
+            buf.fill(0xFFAAAAAA);
+            self.damaged = false;
+        }
+        buf.present().unwrap();
+
         while let Ok(message) = self.rx.pop() {
             println!("Message: {:?}", message);
         }
@@ -29,10 +44,20 @@ impl WindowHandler for OpenWindowExample {
 
                 #[cfg(target_os = "macos")]
                 match e {
-                    MouseEvent::ButtonPressed { .. } => {
-                        copy_to_clipboard(&"This is a test!")
-                    }
+                    MouseEvent::ButtonPressed { .. } => copy_to_clipboard(&"This is a test!"),
                     _ => (),
+                }
+            }
+            Event::Window(WindowEvent::Resized(info)) => {
+                println!("Resized: {:?}", info);
+                let new_size = info.physical_size();
+                self.current_size = new_size;
+
+                if let (Some(width), Some(height)) =
+                    (NonZeroU32::new(new_size.width), NonZeroU32::new(new_size.height))
+                {
+                    self.surface.resize(width, height).unwrap();
+                    self.damaged = true;
                 }
             }
             Event::Keyboard(e) => println!("Keyboard event: {:?}", e),
@@ -56,13 +81,19 @@ fn main() {
 
     let (mut tx, rx) = RingBuffer::new(128);
 
-    ::std::thread::spawn(move || loop {
-        ::std::thread::sleep(Duration::from_secs(5));
+    std::thread::spawn(move || loop {
+        std::thread::sleep(Duration::from_secs(5));
 
         if let Err(_) = tx.push(Message::Hello) {
             println!("Failed sending message");
         }
     });
 
-    Window::open_blocking(window_open_options, |_| OpenWindowExample { rx });
+    Window::open_blocking(window_open_options, |window| {
+        let ctx = unsafe { softbuffer::Context::new(window) }.unwrap();
+        let mut surface = unsafe { softbuffer::Surface::new(&ctx, window) }.unwrap();
+        surface.resize(NonZeroU32::new(512).unwrap(), NonZeroU32::new(512).unwrap()).unwrap();
+
+        OpenWindowExample { ctx, surface, rx, current_size: PhySize::new(512, 512), damaged: true }
+    });
 }

--- a/examples/open_window.rs
+++ b/examples/open_window.rs
@@ -38,16 +38,9 @@ impl WindowHandler for OpenWindowExample {
     }
 
     fn on_event(&mut self, _window: &mut Window, event: Event) -> EventStatus {
-        match event {
-            Event::Mouse(e) => {
-                println!("Mouse event: {:?}", e);
-
-                #[cfg(target_os = "macos")]
-                match e {
-                    MouseEvent::ButtonPressed { .. } => copy_to_clipboard(&"This is a test!"),
-                    _ => (),
-                }
-            }
+        match &event {
+            #[cfg(target_os = "macos")]
+            Event::Mouse(MouseEvent::ButtonPressed { .. }) => copy_to_clipboard(&"This is a test!"),
             Event::Window(WindowEvent::Resized(info)) => {
                 println!("Resized: {:?}", info);
                 let new_size = info.physical_size();
@@ -60,9 +53,10 @@ impl WindowHandler for OpenWindowExample {
                     self.damaged = true;
                 }
             }
-            Event::Keyboard(e) => println!("Keyboard event: {:?}", e),
-            Event::Window(e) => println!("Window event: {:?}", e),
+            _ => {}
         }
+
+        log_event(&event);
 
         EventStatus::Captured
     }
@@ -96,4 +90,12 @@ fn main() {
 
         OpenWindowExample { ctx, surface, rx, current_size: PhySize::new(512, 512), damaged: true }
     });
+}
+
+fn log_event(event: &Event) {
+    match event {
+        Event::Mouse(e) => println!("Mouse event: {:?}", e),
+        Event::Keyboard(e) => println!("Keyboard event: {:?}", e),
+        Event::Window(e) => println!("Window event: {:?}", e),
+    }
 }


### PR DESCRIPTION
This PR adds code to render a basic gray background to the opened window in the `open_window` example.

~~This is done mostly because X11 can get fairly inconsistent with its order of operations when nothing is rendered to it, which can cause it to just never actually show the window.~~ Nevermind, that was a missing flush call on my end. :sweat_smile: 

This also helps making the example a bit more useful, since most users will want to render to their window.

And also it looks nicer. :slightly_smiling_face: 

This is done using the `softbuffer` crate, in the same manner of the `open_parented` introduced in #172.