### PR TITLE
X11: split off Visual Info negotiation into a separate module

### DIFF
--- a/src/x11/mod.rs
+++ b/src/x11/mod.rs
@@ -6,3 +6,4 @@ pub use window::*;
 
 mod cursor;
 mod keyboard;
+mod visual_info;

--- a/src/x11/visual_info.rs
+++ b/src/x11/visual_info.rs
@@ -12,7 +12,7 @@ pub(super) struct WindowVisualConfig {
 
     pub visual_depth: u8,
     pub visual_id: Visualid,
-    pub is_copy_from_parent: bool,
+    pub color_map: Option<Colormap>,
 }
 
 // TODO: make visual negotiation actually check all of a visual's parameters
@@ -20,7 +20,7 @@ impl WindowVisualConfig {
     #[cfg(feature = "opengl")]
     pub fn find_best_visual_config_for_gl(
         connection: &XcbConnection, gl_config: Option<crate::gl::GlConfig>,
-    ) -> Self {
+    ) -> Result<Self, Box<dyn Error>> {
         let Some(gl_config) = gl_config else { return Self::find_best_visual_config(connection) };
 
         // SAFETY: TODO
@@ -29,24 +29,24 @@ impl WindowVisualConfig {
         }
         .expect("Could not fetch framebuffer config");
 
-        Self {
+        Ok(Self {
             fb_config: Some(fb_config),
             visual_depth: window_config.depth,
             visual_id: window_config.visual,
-            is_copy_from_parent: false,
-        }
+            color_map: Some(create_color_map(connection, window_config.visual)?),
+        })
     }
 
-    pub fn find_best_visual_config(connection: &XcbConnection) -> Self {
+    pub fn find_best_visual_config(connection: &XcbConnection) -> Result<Self, Box<dyn Error>> {
         match find_visual_for_depth(connection.screen(), 32) {
-            None => Self::copy_from_parent(),
-            Some(visual_id) => Self {
+            None => Ok(Self::copy_from_parent()),
+            Some(visual_id) => Ok(Self {
                 #[cfg(feature = "opengl")]
                 fb_config: None,
                 visual_id,
                 visual_depth: 32,
-                is_copy_from_parent: false,
-            },
+                color_map: Some(create_color_map(connection, visual_id)?),
+            }),
         }
     }
 
@@ -56,29 +56,25 @@ impl WindowVisualConfig {
             fb_config: None,
             visual_depth: COPY_FROM_PARENT as u8,
             visual_id: COPY_FROM_PARENT,
-            is_copy_from_parent: true,
+            color_map: None,
         }
     }
+}
 
-    // For this 32-bit depth to work, you also need to define a color map and set a border
-    // pixel: https://cgit.freedesktop.org/xorg/xserver/tree/dix/window.c#n818
-    pub fn create_color_map(
-        &self, connection: &XcbConnection,
-    ) -> Result<Option<Colormap>, Box<dyn Error>> {
-        if self.is_copy_from_parent {
-            return Ok(None);
-        }
+// For this 32-bit depth to work, you also need to define a color map and set a border
+// pixel: https://cgit.freedesktop.org/xorg/xserver/tree/dix/window.c#n818
+pub fn create_color_map(
+    connection: &XcbConnection, visual_id: Visualid,
+) -> Result<Colormap, Box<dyn Error>> {
+    let colormap = connection.conn2.generate_id()?;
+    connection.conn2.create_colormap(
+        ColormapAlloc::NONE,
+        colormap,
+        connection.screen().root,
+        visual_id,
+    )?;
 
-        let colormap = connection.conn2.generate_id()?;
-        connection.conn2.create_colormap(
-            ColormapAlloc::NONE,
-            colormap,
-            connection.screen().root,
-            self.visual_id,
-        )?;
-
-        Ok(Some(colormap))
-    }
+    Ok(colormap)
 }
 
 fn find_visual_for_depth(screen: &Screen, depth: u8) -> Option<Visualid> {

--- a/src/x11/visual_info.rs
+++ b/src/x11/visual_info.rs
@@ -66,8 +66,8 @@ impl WindowVisualConfig {
 pub fn create_color_map(
     connection: &XcbConnection, visual_id: Visualid,
 ) -> Result<Colormap, Box<dyn Error>> {
-    let colormap = connection.conn2.generate_id()?;
-    connection.conn2.create_colormap(
+    let colormap = connection.conn.generate_id()?;
+    connection.conn.create_colormap(
         ColormapAlloc::NONE,
         colormap,
         connection.screen().root,

--- a/src/x11/visual_info.rs
+++ b/src/x11/visual_info.rs
@@ -1,0 +1,98 @@
+use crate::x11::xcb_connection::XcbConnection;
+use std::error::Error;
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{
+    Colormap, ColormapAlloc, ConnectionExt, Screen, VisualClass, Visualid,
+};
+use x11rb::COPY_FROM_PARENT;
+
+pub(super) struct WindowVisualConfig {
+    #[cfg(feature = "opengl")]
+    pub fb_config: Option<crate::gl::x11::FbConfig>,
+
+    pub visual_depth: u8,
+    pub visual_id: Visualid,
+    pub is_copy_from_parent: bool,
+}
+
+// TODO: make visual negotiation actually check all of a visual's parameters
+impl WindowVisualConfig {
+    #[cfg(feature = "opengl")]
+    pub fn find_best_visual_config_for_gl(
+        connection: &XcbConnection, gl_config: Option<crate::gl::GlConfig>,
+    ) -> Self {
+        let Some(gl_config) = gl_config else { return Self::find_best_visual_config(connection) };
+
+        // SAFETY: TODO
+        let (fb_config, window_config) = unsafe {
+            crate::gl::platform::GlContext::get_fb_config_and_visual(connection.dpy, gl_config)
+        }
+        .expect("Could not fetch framebuffer config");
+
+        Self {
+            fb_config: Some(fb_config),
+            visual_depth: window_config.depth,
+            visual_id: window_config.visual,
+            is_copy_from_parent: false,
+        }
+    }
+
+    pub fn find_best_visual_config(connection: &XcbConnection) -> Self {
+        match find_visual_for_depth(connection.screen(), 32) {
+            None => Self::copy_from_parent(),
+            Some(visual_id) => Self {
+                #[cfg(feature = "opengl")]
+                fb_config: None,
+                visual_id,
+                visual_depth: 32,
+                is_copy_from_parent: false,
+            },
+        }
+    }
+
+    const fn copy_from_parent() -> Self {
+        Self {
+            #[cfg(feature = "opengl")]
+            fb_config: None,
+            visual_depth: COPY_FROM_PARENT as u8,
+            visual_id: COPY_FROM_PARENT,
+            is_copy_from_parent: true,
+        }
+    }
+
+    // For this 32-bit depth to work, you also need to define a color map and set a border
+    // pixel: https://cgit.freedesktop.org/xorg/xserver/tree/dix/window.c#n818
+    pub fn create_color_map(
+        &self, connection: &XcbConnection,
+    ) -> Result<Option<Colormap>, Box<dyn Error>> {
+        if self.is_copy_from_parent {
+            return Ok(None);
+        }
+
+        let colormap = connection.conn2.generate_id()?;
+        connection.conn2.create_colormap(
+            ColormapAlloc::NONE,
+            colormap,
+            connection.screen().root,
+            self.visual_id,
+        )?;
+
+        Ok(Some(colormap))
+    }
+}
+
+fn find_visual_for_depth(screen: &Screen, depth: u8) -> Option<Visualid> {
+    for candidate_depth in &screen.allowed_depths {
+        if candidate_depth.depth != depth {
+            continue;
+        }
+
+        for candidate_visual in &candidate_depth.visuals {
+            if candidate_visual.class == VisualClass::TRUE_COLOR {
+                return Some(candidate_visual.visual_id);
+            }
+        }
+    }
+
+    None
+}

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -207,12 +207,10 @@ impl<'a> Window<'a> {
 
         #[cfg(feature = "opengl")]
         let visual_info =
-            WindowVisualConfig::find_best_visual_config_for_gl(&xcb_connection, options.gl_config);
+            WindowVisualConfig::find_best_visual_config_for_gl(&xcb_connection, options.gl_config)?;
 
         #[cfg(not(feature = "opengl"))]
-        let visual_info = WindowVisualConfig::find_best_visual_config(&xcb_connection);
-
-        let color_map = visual_info.create_color_map(&xcb_connection)?;
+        let visual_info = WindowVisualConfig::find_best_visual_config(&xcb_connection)?;
 
         let window_id = xcb_connection.conn.generate_id()?;
         xcb_connection.conn.create_window(
@@ -240,7 +238,7 @@ impl<'a> Window<'a> {
                 )
                 // As mentioned above, these two values are needed to be able to create a window
                 // with a depth of 32-bits when the parent window has a different depth
-                .colormap(color_map)
+                .colormap(visual_info.color_map)
                 .border_pixel(0),
         )?;
         xcb_connection.conn.map_window(window_id)?;

--- a/src/x11/xcb_connection.rs
+++ b/src/x11/xcb_connection.rs
@@ -5,7 +5,7 @@ use x11::{xlib, xlib::Display, xlib_xcb};
 
 use x11rb::connection::Connection;
 use x11rb::cursor::Handle as CursorHandle;
-use x11rb::protocol::xproto::Cursor;
+use x11rb::protocol::xproto::{Cursor, Screen};
 use x11rb::resource_manager;
 use x11rb::xcb_ffi::XCBConnection;
 
@@ -76,8 +76,7 @@ impl XcbConnection {
     // If neither work, I guess just assume 96.0 and don't do any scaling.
     fn get_scaling_screen_dimensions(&self) -> f64 {
         // Figure out screen information
-        let setup = self.conn.setup();
-        let screen = &setup.roots[self.screen];
+        let screen = self.screen();
 
         // Get the DPI from the screen struct
         //
@@ -114,5 +113,9 @@ impl XcbConnection {
                 Ok(cursor)
             }
         }
+    }
+
+    pub fn screen(&self) -> &Screen {
+        &self.conn2.setup().roots[self.screen]
     }
 }

--- a/src/x11/xcb_connection.rs
+++ b/src/x11/xcb_connection.rs
@@ -116,6 +116,6 @@ impl XcbConnection {
     }
 
     pub fn screen(&self) -> &Screen {
-        &self.conn2.setup().roots[self.screen]
+        &self.conn.setup().roots[self.screen]
     }
 }


### PR DESCRIPTION
This PR refactors and splits off the X11 visual info negotiation code into its own module and type. This should not change the actual logic at all however.

This is part of the effort to split up #174 into smaller pieces.