### PR TITLE
Add additional CI checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,6 @@ env:
 
 jobs:
   build:
-    name: Build & Test
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -34,7 +33,7 @@ jobs:
       run: cargo doc --examples --all-features --no-deps
     - name: Clippy
       run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-    - name: Format
+    - name: Check Formatting (rustfmt)
       run: cargo fmt --all -- --check
 
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
+  build:
     name: Build & Test
     strategy:
       matrix:
@@ -23,6 +23,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
+        components: rustfmt, clippy
     - name: Build Default
       run: cargo build --workspace --all-targets --verbose
     - name: Build All Features
@@ -31,32 +32,9 @@ jobs:
       run: cargo test --workspace --all-targets --all-features --verbose
     - name: Check docs
       run: cargo doc --examples --all-features --no-deps
+    - name: Clippy
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+    - name: Format
+      run: cargo fmt --all -- --check
 
-  clippy:
-    name: Clippy
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: clippy
-      - name: Install XCB and GL dependencies
-        if: contains(matrix.os, 'ubuntu')
-        run: sudo apt-get install libx11-xcb-dev libxcb-dri2-0-dev libgl1-mesa-dev libxcb-icccm4-dev libxcursor-dev
-      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
-  rustfmt:
-    name: Format check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: rustfmt
-      - name: Format
-        run: cargo fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,29 +1,62 @@
 name: Rust
 
 on: [push, pull_request]
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
+  test:
+    name: Build & Test
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-
+    runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: -D warnings
+      RUSTDOCFLAGS: -D warnings
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install XCB and GL dependencies
-      run: |
-        sudo apt update
-        sudo apt install libx11-xcb-dev libxcb-dri2-0-dev libgl1-mesa-dev libxcb-icccm4-dev libxcursor-dev
       if: contains(matrix.os, 'ubuntu')
+      run: sudo apt-get install libx11-xcb-dev libxcb-dri2-0-dev libgl1-mesa-dev libxcb-icccm4-dev libxcursor-dev
     - name: Install rust stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        override: true
-    - name: Build with default features
-      run: cargo build --examples --workspace --verbose
-    - name: Build again with all features
-      run: cargo build --examples --workspace --all-features --verbose
+    - name: Build Default
+      run: cargo build --workspace --all-targets --verbose
+    - name: Build All Features
+      run: cargo build --workspace --all-targets --all-features --verbose
     - name: Run tests
-      run: cargo test --examples --workspace --all-features --verbose
+      run: cargo test --workspace --all-targets --all-features --verbose
+    - name: Check docs
+      run: cargo doc --examples --all-features --no-deps
+
+  clippy:
+    name: Clippy
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: clippy
+      - name: Install XCB and GL dependencies
+        if: contains(matrix.os, 'ubuntu')
+        run: sudo apt-get install libx11-xcb-dev libxcb-dri2-0-dev libgl1-mesa-dev libxcb-icccm4-dev libxcursor-dev
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  rustfmt:
+    name: Format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt
+      - name: Format
+        run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,16 @@ softbuffer = "0.3.4"
 
 [workspace]
 members = ["examples/render_femtovg"]
+
+[lints.clippy]
+missing-safety-doc = "allow"
+
+[[example]]
+name = "open_window"
+test = true
+doctest = true
+
+[[example]]
+name = "open_parented"
+test = true
+doctest = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+msrv = '1.59'
+check-private-items = true

--- a/examples/open_window.rs
+++ b/examples/open_window.rs
@@ -40,7 +40,7 @@ impl WindowHandler for OpenWindowExample {
     fn on_event(&mut self, _window: &mut Window, event: Event) -> EventStatus {
         match &event {
             #[cfg(target_os = "macos")]
-            Event::Mouse(MouseEvent::ButtonPressed { .. }) => copy_to_clipboard(&"This is a test!"),
+            Event::Mouse(MouseEvent::ButtonPressed { .. }) => copy_to_clipboard("This is a test!"),
             Event::Window(WindowEvent::Resized(info)) => {
                 println!("Resized: {:?}", info);
                 let new_size = info.physical_size();
@@ -78,7 +78,7 @@ fn main() {
     std::thread::spawn(move || loop {
         std::thread::sleep(Duration::from_secs(5));
 
-        if let Err(_) = tx.push(Message::Hello) {
+        if tx.push(Message::Hello).is_err() {
             println!("Failed sending message");
         }
     });

--- a/src/gl/macos.rs
+++ b/src/gl/macos.rs
@@ -121,10 +121,8 @@ impl GlContext {
         let framework_name = CFString::from_str("com.apple.opengl").unwrap();
         let framework =
             unsafe { CFBundleGetBundleWithIdentifier(framework_name.as_concrete_TypeRef()) };
-        let addr = unsafe {
-            CFBundleGetFunctionPointerForName(framework, symbol_name.as_concrete_TypeRef())
-        };
-        addr as *const c_void
+
+        unsafe { CFBundleGetFunctionPointerForName(framework, symbol_name.as_concrete_TypeRef()) }
     }
 
     pub fn swap_buffers(&self) {

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -43,7 +43,6 @@ impl WindowHandle {
     pub fn is_open(&self) -> bool {
         self.state.window_inner.open.get()
     }
-
 }
 
 unsafe impl HasRawWindowHandle for WindowHandle {
@@ -289,7 +288,9 @@ impl<'a> Window<'a> {
         unsafe {
             let view = self.inner.ns_view.as_mut().unwrap();
             let window: id = msg_send![view, window];
-            if window == nil { return false; };
+            if window == nil {
+                return false;
+            };
             let first_responder: id = msg_send![window, firstResponder];
             let is_key_window: BOOL = msg_send![window, isKeyWindow];
             let is_focused: BOOL = msg_send![view, isEqual: first_responder];

--- a/src/win/drop_target.rs
+++ b/src/win/drop_target.rs
@@ -15,7 +15,7 @@ use winapi::um::oleidl::{
     IDropTarget, IDropTargetVtbl, DROPEFFECT_COPY, DROPEFFECT_LINK, DROPEFFECT_MOVE,
     DROPEFFECT_NONE, DROPEFFECT_SCROLL,
 };
-use winapi::um::shellapi::DragQueryFileW;
+use winapi::um::shellapi::{DragQueryFileW, HDROP};
 use winapi::um::unknwnbase::{IUnknown, IUnknownVtbl};
 use winapi::um::winuser::CF_HDROP;
 use winapi::Interface;
@@ -135,7 +135,7 @@ impl DropTarget {
                 return;
             }
 
-            let hdrop = transmute((*medium.u).hGlobal());
+            let hdrop = *(*medium.u).hGlobal() as HDROP;
 
             let item_count = DragQueryFileW(hdrop, 0xFFFFFFFF, null_mut(), 0);
             if item_count == 0 {
@@ -153,7 +153,7 @@ impl DropTarget {
                 DragQueryFileW(
                     hdrop,
                     i,
-                    transmute(buffer.spare_capacity_mut().as_mut_ptr()),
+                    buffer.spare_capacity_mut().as_mut_ptr().cast(),
                     buffer_size as u32,
                 );
                 buffer.set_len(buffer_size);
@@ -175,7 +175,7 @@ impl DropTarget {
             return S_OK;
         }
 
-        return E_NOINTERFACE;
+        E_NOINTERFACE
     }
 
     unsafe extern "system" fn add_ref(this: *mut IUnknown) -> ULONG {

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -6,9 +6,9 @@ use winapi::um::ole2::{OleInitialize, RegisterDragDrop, RevokeDragDrop};
 use winapi::um::oleidl::LPDROPTARGET;
 use winapi::um::winuser::{
     AdjustWindowRectEx, CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW,
-    GetDpiForWindow, GetMessageW, GetWindowLongPtrW, LoadCursorW, PostMessageW, RegisterClassW,
-    ReleaseCapture, SetCapture, SetProcessDpiAwarenessContext, SetTimer, SetWindowLongPtrW,
-    SetWindowPos, SetFocus, GetFocus, TrackMouseEvent, TranslateMessage, UnregisterClassW, CS_OWNDC,
+    GetDpiForWindow, GetFocus, GetMessageW, GetWindowLongPtrW, LoadCursorW, PostMessageW,
+    RegisterClassW, ReleaseCapture, SetCapture, SetFocus, SetProcessDpiAwarenessContext, SetTimer,
+    SetWindowLongPtrW, SetWindowPos, TrackMouseEvent, TranslateMessage, UnregisterClassW, CS_OWNDC,
     GET_XBUTTON_WPARAM, GWLP_USERDATA, IDC_ARROW, MSG, SWP_NOMOVE, SWP_NOZORDER, TRACKMOUSEEVENT,
     WHEEL_DELTA, WM_CHAR, WM_CLOSE, WM_CREATE, WM_DPICHANGED, WM_INPUTLANGCHANGE, WM_KEYDOWN,
     WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL,
@@ -174,7 +174,7 @@ unsafe fn wnd_proc_inner(
             if *mouse_was_outside_window {
                 // this makes Windows track whether the mouse leaves the window.
                 // When the mouse leaves it results in a `WM_MOUSELEAVE` event.
-                let mut track_mouse =TRACKMOUSEEVENT {
+                let mut track_mouse = TRACKMOUSEEVENT {
                     cbSize: std::mem::size_of::<TRACKMOUSEEVENT>() as u32,
                     dwFlags: winapi::um::winuser::TME_LEAVE,
                     hwndTrack: hwnd,
@@ -186,7 +186,12 @@ unsafe fn wnd_proc_inner(
                 *mouse_was_outside_window = false;
 
                 let enter_event = Event::Mouse(MouseEvent::CursorEntered);
-                window_state.handler.borrow_mut().as_mut().unwrap().on_event(&mut window, enter_event);
+                window_state
+                    .handler
+                    .borrow_mut()
+                    .as_mut()
+                    .unwrap()
+                    .on_event(&mut window, enter_event);
             }
 
             let x = (lparam & 0xFFFF) as i16 as i32;

--- a/src/window.rs
+++ b/src/window.rs
@@ -23,7 +23,7 @@ pub struct WindowHandle {
 
 impl WindowHandle {
     fn new(window_handle: platform::WindowHandle) -> Self {
-        Self { window_handle, phantom: PhantomData::default() }
+        Self { window_handle, phantom: PhantomData }
     }
 
     /// Close the window

--- a/src/x11/xcb_connection.rs
+++ b/src/x11/xcb_connection.rs
@@ -91,10 +91,8 @@ impl XcbConnection {
         let _xres = width_px * 25.4 / width_mm;
         let yres = height_px * 25.4 / height_mm;
 
-        let yscale = yres / 96.0;
-
         // TODO: choose between `xres` and `yres`? (probably both are the same?)
-        yscale
+        yres / 96.0
     }
 
     #[inline]


### PR DESCRIPTION
This PR adds a variety of checks to the CI:

* Check that all code and examples build without warnings using `-D warnings`. This is done for all platforms, with or without the OpenGL feature.
* Check that all documentation is valid, and that no documentation links are broken, using `cargo doc` with `-D warnings`.
* Run `clippy` with `-D warnings` (but otherwise only the default lints).
* Check formatting using `rustfmt`.

This PR also applies some light formatting and code fixes that were detected by `rustfmt` and `clippy`.

This also makes some updates to the actions used:
* Update `actions/checkout` to `v4`
* Replace `actions-rs/toolchain` (which is not maintained anymore) to `dtolnay/rust-toolchain` instead

Some further work that is not covered by this PR:
* The `missing-safety-doc` lint has been temporarily disabled. This will be re-enabled in another PR that will add the proper safety docs to the affected functions.
* `cargo-deny` has been discussed, but I prefer adding it in a later PR as it can be its own can of worms regarding licenses and dependencies.