### PR TITLE
Call XCloseDisplay instead of xcb_disconnect

### DIFF
--- a/src/x11/xcb_connection.rs
+++ b/src/x11/xcb_connection.rs
@@ -40,7 +40,7 @@ impl XcbConnection {
         let xcb_connection = unsafe { xlib_xcb::XGetXCBConnection(dpy) };
         assert!(!xcb_connection.is_null());
         let screen = unsafe { xlib::XDefaultScreen(dpy) } as usize;
-        let conn = unsafe { XCBConnection::from_raw_xcb_connection(xcb_connection, true)? };
+        let conn = unsafe { XCBConnection::from_raw_xcb_connection(xcb_connection, false)? };
         unsafe {
             xlib_xcb::XSetEventQueueOwner(dpy, xlib_xcb::XEventQueueOwner::XCBOwnsEventQueue)
         };
@@ -117,5 +117,13 @@ impl XcbConnection {
 
     pub fn screen(&self) -> &Screen {
         &self.conn.setup().roots[self.screen]
+    }
+}
+
+impl Drop for XcbConnection {
+    fn drop(&mut self) {
+        unsafe {
+            xlib::XCloseDisplay(self.dpy);
+        }
     }
 }


### PR DESCRIPTION
Pass `false` for the `should_drop` argument of [`XCBConnection::from_raw_xcb_connection`](https://docs.rs/x11rb/0.13.0/x11rb/xcb_ffi/struct.XCBConnection.html#method.from_raw_xcb_connection), so that it doesn't implicitly call `xcb_disconnect` on drop. Instead, explicitly call `XCloseDisplay` on drop, since the connection was originally created with `XOpenDisplay`.