### PR TITLE
Remove unnecessary dependences from CI pipeline and README

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install XCB and GL dependencies
       if: contains(matrix.os, 'ubuntu')
-      run: sudo apt-get install libx11-xcb-dev libxcb-dri2-0-dev libgl1-mesa-dev libxcb-icccm4-dev libxcursor-dev
+      run: sudo apt-get install libx11-dev libxcb1-dev libx11-xcb-dev libgl1-mesa-dev
     - name: Install rust stable
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -35,5 +35,3 @@ jobs:
       run: cargo clippy --workspace --all-targets --all-features -- -D warnings
     - name: Check Formatting (rustfmt)
       run: cargo fmt --all -- --check
-
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ raw-window-handle = "0.5"
 
 [target.'cfg(target_os="linux")'.dependencies]
 x11rb = { version = "0.13.0", features = ["cursor", "resource_manager", "allow-unsafe-code"] }
-x11 = { version = "2.21", features = ["xlib", "xcursor", "xlib_xcb"] }
+x11 = { version = "2.21", features = ["xlib", "xlib_xcb"] }
 nix = "0.22.0"
 
 [target.'cfg(target_os="windows")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Below is a proposed list of milestones (roughly in-order) and their status. Subj
 
 ### Linux
 
-Install dependencies, e.g.,
+Install dependencies, e.g.:
 
 ```sh
-sudo apt-get install libx11-dev libxcursor-dev libxcb-dri2-0-dev libxcb-icccm4-dev libx11-xcb-dev
+sudo apt-get install libx11-dev libxcb1-dev libx11-xcb-dev libgl1-mesa-dev
 ```
 
 ## License


### PR DESCRIPTION
After switching to `x11rb`, the `libxcb-icccm4-dev` and `libxcursor-dev` dependencies are no longer necessary. I don't believe the `libxcb-dri2-0-dev` dependency was ever necessary.