### PR TITLE
Handle set_mouse_cursor event on windows

### DIFF
--- a/src/mouse_cursor.rs
+++ b/src/mouse_cursor.rs
@@ -41,9 +41,3 @@ pub enum MouseCursor {
     ColResize,
     RowResize,
 }
-
-impl Default for MouseCursor {
-    fn default() -> Self {
-        Self::Default
-    }
-}

--- a/src/mouse_cursor.rs
+++ b/src/mouse_cursor.rs
@@ -41,3 +41,9 @@ pub enum MouseCursor {
     ColResize,
     RowResize,
 }
+
+impl Default for MouseCursor {
+    fn default() -> Self {
+        Self::Default
+    }
+}

--- a/src/win/cursor.rs
+++ b/src/win/cursor.rs
@@ -1,0 +1,55 @@
+use crate::MouseCursor;
+use winapi::{
+    shared::ntdef::LPCWSTR,
+    um::winuser::{
+        IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_HELP, IDC_IBEAM, IDC_NO, IDC_SIZEALL,
+        IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_WAIT,
+    },
+};
+
+pub fn cursor_to_lpcwstr(cursor: MouseCursor) -> LPCWSTR {
+    match cursor {
+        MouseCursor::Default => IDC_ARROW,
+        MouseCursor::Hand => IDC_HAND,
+        MouseCursor::HandGrabbing => IDC_SIZEALL,
+        MouseCursor::Help => IDC_HELP,
+
+        // hiding cursor can't be turned into an lpcwstr since it's done by ShowCursor instead of SetCursor
+        MouseCursor::Hidden => IDC_ARROW,
+
+        MouseCursor::Text => IDC_IBEAM,
+        MouseCursor::VerticalText => IDC_IBEAM,
+
+        MouseCursor::Working => IDC_WAIT,
+        MouseCursor::PtrWorking => IDC_APPSTARTING,
+
+        MouseCursor::NotAllowed => IDC_NO,
+        MouseCursor::PtrNotAllowed => IDC_NO,
+
+        MouseCursor::ZoomIn => IDC_ARROW,
+        MouseCursor::ZoomOut => IDC_ARROW,
+
+        MouseCursor::Alias => IDC_ARROW,
+        MouseCursor::Copy => IDC_ARROW,
+        MouseCursor::Move => IDC_SIZEALL,
+        MouseCursor::AllScroll => IDC_SIZEALL,
+        MouseCursor::Cell => IDC_CROSS,
+        MouseCursor::Crosshair => IDC_CROSS,
+
+        MouseCursor::EResize => IDC_SIZEWE,
+        MouseCursor::NResize => IDC_SIZENS,
+        MouseCursor::NeResize => IDC_SIZENESW,
+        MouseCursor::NwResize => IDC_SIZENWSE,
+        MouseCursor::SResize => IDC_SIZENS,
+        MouseCursor::SeResize => IDC_SIZENWSE,
+        MouseCursor::SwResize => IDC_SIZENESW,
+        MouseCursor::WResize => IDC_SIZEWE,
+        MouseCursor::EwResize => IDC_SIZEWE,
+        MouseCursor::NsResize => IDC_SIZENS,
+        MouseCursor::NwseResize => IDC_SIZENWSE,
+        MouseCursor::NeswResize => IDC_SIZENESW,
+
+        MouseCursor::ColResize => IDC_SIZEWE,
+        MouseCursor::RowResize => IDC_SIZENS,
+    }
+}

--- a/src/win/cursor.rs
+++ b/src/win/cursor.rs
@@ -13,9 +13,8 @@ pub fn cursor_to_lpcwstr(cursor: MouseCursor) -> LPCWSTR {
         MouseCursor::Hand => IDC_HAND,
         MouseCursor::HandGrabbing => IDC_SIZEALL,
         MouseCursor::Help => IDC_HELP,
-
-        // hiding cursor can't be turned into an lpcwstr since it's done by ShowCursor instead of SetCursor
-        MouseCursor::Hidden => IDC_ARROW,
+        // an empty LPCWSTR results in the cursor being hidden
+        MouseCursor::Hidden => std::ptr::null(),
 
         MouseCursor::Text => IDC_IBEAM,
         MouseCursor::VerticalText => IDC_IBEAM,

--- a/src/win/mod.rs
+++ b/src/win/mod.rs
@@ -1,3 +1,4 @@
+mod cursor;
 mod drop_target;
 mod keyboard;
 mod window;


### PR DESCRIPTION
This adds the ability to change the cursor on Windows platforms. For some reason there are very few default cursors included in Windows so a lot of cursors available on other platforms aren't available yet, which is why many of the `MouseCursor` options just maps to `IDC_ARROW`. I'll look into adding custom cursors next.

`LoadCursorW` is supposedly superseded by [LoadImageW](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadcursorw) but I couldn't find a way to do it with that one that doesn't crash. 

Tested with Vizia's cursor icon example [here](https://github.com/Fredemus/vizia/tree/baseview-window-events) and everything seems to work as it should.
Also tested by hovering over some buttons on a plugin.