### PR TITLE
defer certain events on macOS to avoid re-entrant calls

### DIFF
--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -249,14 +249,14 @@ extern "C" fn become_first_responder(this: &Object, _sel: Sel) -> BOOL {
         is_key_window == YES
     };
     if is_key_window {
-        state.trigger_event(Event::Window(WindowEvent::Focused));
+        state.defer_event(Event::Window(WindowEvent::Focused));
     }
     YES
 }
 
 extern "C" fn resign_first_responder(this: &Object, _sel: Sel) -> BOOL {
     let state = unsafe { WindowState::from_view(this) };
-    state.trigger_event(Event::Window(WindowEvent::Unfocused));
+    state.defer_event(Event::Window(WindowEvent::Unfocused));
     YES
 }
 


### PR DESCRIPTION
previously, calling `window.focus()` would cause a crash in some scenarios, because certain members of `WindowState` were borrowed mutably while already being borrowed. this PR fixes the issue by deferring window focus events to be triggered before calling `WindowHandler:on_frame()`.