### PR TITLE
simple wgpu example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ rtrb = "0.2"
 softbuffer = "0.3.4"
 
 [workspace]
-members = ["examples/render_femtovg"]
+members = ["examples/render_femtovg", "examples/render_wgpu"]
 
 [lints.clippy]
 missing-safety-doc = "allow"

--- a/examples/render_wgpu/Cargo.toml
+++ b/examples/render_wgpu/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 wgpu = "0.18"
-baseview = {path = "../.."}
+baseview = {path = "../..", features = ["opengl"]}
 pollster = "0.3.0"

--- a/examples/render_wgpu/Cargo.toml
+++ b/examples/render_wgpu/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 wgpu = "0.18"
 baseview = {path = "../..", features = ["opengl"]}
 pollster = "0.3.0"
+bytemuck = {version = "1.15.0", features = ["derive"]}

--- a/examples/render_wgpu/Cargo.toml
+++ b/examples/render_wgpu/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "render_wgpu"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+wgpu = "0.18"
+baseview = {path = "../.."}
+pollster = "0.3.0"

--- a/examples/render_wgpu/src/main.rs
+++ b/examples/render_wgpu/src/main.rs
@@ -1,4 +1,4 @@
-use baseview::{Size, Window, WindowHandler, WindowOpenOptions};
+use baseview::{MouseEvent, Size, Window, WindowHandler, WindowInfo, WindowOpenOptions};
 use wgpu::{util::DeviceExt, Buffer, Device, Queue, RenderPipeline, Surface};
 
 struct WgpuExample {
@@ -35,7 +35,7 @@ impl<'a> WgpuExample {
 
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Vertex Buffer"),
-            contents: bytemuck::cast_slice(VERTICES),
+            contents: bytemuck::cast_slice(VERTICES_START),
             usage: wgpu::BufferUsages::VERTEX,
         });
 
@@ -142,8 +142,34 @@ impl WindowHandler for WgpuExample {
         output.present();
     }
     fn on_event(
-        &mut self, _window: &mut baseview::Window, _event: baseview::Event,
+        &mut self, _window: &mut baseview::Window, event: baseview::Event,
     ) -> baseview::EventStatus {
+        match event {
+            baseview::Event::Mouse(MouseEvent::CursorMoved { position, modifiers: _ }) => {
+                let center_x: f32 = (position.x as f32 - 256.0) / 256.0;
+                let center_y: f32 = (256.0 - position.y as f32) / 256.0;
+                let vertices = &[
+                    Vertex { position: [center_x, center_y + 0.25, 0.0], color: [1.0, 0.0, 0.0] },
+                    Vertex {
+                        position: [center_x - 0.25, center_y - 0.25, 0.0],
+                        color: [0.0, 1.0, 0.0],
+                    },
+                    Vertex {
+                        position: [center_x + 0.25, center_y - 0.25, 0.0],
+                        color: [0.0, 0.0, 1.0],
+                    },
+                ];
+                let vertex_buffer =
+                    self.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                        label: Some("Vertex Buffer"),
+                        contents: bytemuck::cast_slice(vertices),
+                        usage: wgpu::BufferUsages::VERTEX,
+                    });
+
+                self.vertex_buffer = vertex_buffer;
+            }
+            _ => {}
+        }
         baseview::EventStatus::Captured
     }
 }
@@ -155,10 +181,10 @@ struct Vertex {
     color: [f32; 3],
 }
 
-const VERTICES: &[Vertex] = &[
-    Vertex { position: [0.0, 0.5, 0.0], color: [1.0, 0.0, 0.0] },
-    Vertex { position: [-0.5, -0.5, 0.0], color: [0.0, 1.0, 0.0] },
-    Vertex { position: [0.5, -0.5, 0.0], color: [0.0, 0.0, 1.0] },
+const VERTICES_START: &[Vertex] = &[
+    Vertex { position: [0.0, 0.25, 0.0], color: [1.0, 0.0, 0.0] },
+    Vertex { position: [-0.25, -0.25, 0.0], color: [0.0, 1.0, 0.0] },
+    Vertex { position: [0.25, -0.25, 0.0], color: [0.0, 0.0, 1.0] },
 ];
 
 impl Vertex {

--- a/examples/render_wgpu/src/main.rs
+++ b/examples/render_wgpu/src/main.rs
@@ -44,8 +44,7 @@ impl<'a> WgpuExample {
             .formats
             .iter()
             .copied()
-            .filter(|f| f.is_srgb())
-            .next()
+            .find(|f| f.is_srgb())
             .unwrap_or(surface_caps.formats[0]);
         let config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
@@ -144,31 +143,27 @@ impl WindowHandler for WgpuExample {
     fn on_event(
         &mut self, _window: &mut baseview::Window, event: baseview::Event,
     ) -> baseview::EventStatus {
-        match event {
-            baseview::Event::Mouse(MouseEvent::CursorMoved { position, modifiers: _ }) => {
-                let center_x: f32 = (position.x as f32 - 256.0) / 256.0;
-                let center_y: f32 = (256.0 - position.y as f32) / 256.0;
-                let vertices = &[
-                    Vertex { position: [center_x, center_y + 0.25, 0.0], color: [1.0, 0.0, 0.0] },
-                    Vertex {
-                        position: [center_x - 0.25, center_y - 0.25, 0.0],
-                        color: [0.0, 1.0, 0.0],
-                    },
-                    Vertex {
-                        position: [center_x + 0.25, center_y - 0.25, 0.0],
-                        color: [0.0, 0.0, 1.0],
-                    },
-                ];
-                let vertex_buffer =
-                    self.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                        label: Some("Vertex Buffer"),
-                        contents: bytemuck::cast_slice(vertices),
-                        usage: wgpu::BufferUsages::VERTEX,
-                    });
+        if let baseview::Event::Mouse(MouseEvent::CursorMoved { position, modifiers: _ }) = event {
+            let center_x: f32 = (position.x as f32 - 256.0) / 256.0;
+            let center_y: f32 = (256.0 - position.y as f32) / 256.0;
+            let vertices = &[
+                Vertex { position: [center_x, center_y + 0.25, 0.0], color: [1.0, 0.0, 0.0] },
+                Vertex {
+                    position: [center_x - 0.25, center_y - 0.25, 0.0],
+                    color: [0.0, 1.0, 0.0],
+                },
+                Vertex {
+                    position: [center_x + 0.25, center_y - 0.25, 0.0],
+                    color: [0.0, 0.0, 1.0],
+                },
+            ];
+            let vertex_buffer = self.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Vertex Buffer"),
+                contents: bytemuck::cast_slice(vertices),
+                usage: wgpu::BufferUsages::VERTEX,
+            });
 
-                self.vertex_buffer = vertex_buffer;
-            }
-            _ => {}
+            self.vertex_buffer = vertex_buffer;
         }
         baseview::EventStatus::Captured
     }

--- a/examples/render_wgpu/src/main.rs
+++ b/examples/render_wgpu/src/main.rs
@@ -1,4 +1,4 @@
-use baseview::{MouseEvent, Size, Window, WindowHandler, WindowInfo, WindowOpenOptions};
+use baseview::{MouseEvent, Size, Window, WindowHandler, WindowOpenOptions};
 use wgpu::{util::DeviceExt, Buffer, Device, Queue, RenderPipeline, Surface};
 
 struct WgpuExample {

--- a/examples/render_wgpu/src/main.rs
+++ b/examples/render_wgpu/src/main.rs
@@ -1,0 +1,148 @@
+use baseview::{Size, Window, WindowHandler, WindowOpenOptions};
+use wgpu::{Device, RenderPipeline, Surface};
+
+struct WgpuExample {
+    pipeline: RenderPipeline,
+    surface: Surface,
+    device: Device,
+}
+
+impl<'a> WgpuExample {
+    pub async fn new(window: &mut Window<'a>) -> Self {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
+        let surface = unsafe { instance.create_surface(window) }.unwrap();
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::default(),
+                compatible_surface: Some(&surface),
+                force_fallback_adapter: false,
+            })
+            .await
+            .unwrap();
+        let (device, _queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    features: wgpu::Features::empty(),
+                    limits: wgpu::Limits::default(),
+                    label: None,
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let surface_caps = surface.get_capabilities(&adapter);
+        let surface_format = surface_caps
+            .formats
+            .iter()
+            .copied()
+            .filter(|f| f.is_srgb())
+            .next()
+            .unwrap_or(surface_caps.formats[0]);
+        let config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: surface_format,
+            width: 512,
+            height: 512,
+            present_mode: surface_caps.present_modes[0],
+            alpha_mode: surface_caps.alpha_modes[0],
+            view_formats: vec![],
+        };
+
+        let shader = device.create_shader_module(wgpu::include_wgsl!("shader.wgsl"));
+
+        let render_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Render Pipeline Layout"),
+                bind_group_layouts: &[],
+                push_constant_ranges: &[],
+            });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Render Pipeline"),
+            layout: Some(&render_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main", // 1.
+                buffers: &[],           // 2.
+            },
+            fragment: Some(wgpu::FragmentState {
+                // 3.
+                module: &shader,
+                entry_point: "fs_main",
+                targets: &[Some(wgpu::ColorTargetState {
+                    // 4.
+                    format: config.format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList, // 1.
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw, // 2.
+                cull_mode: Some(wgpu::Face::Back),
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None, // 1.
+            multisample: wgpu::MultisampleState {
+                count: 1,                         // 2.
+                mask: !0,                         // 3.
+                alpha_to_coverage_enabled: false, // 4.
+            },
+            multiview: None,
+        });
+
+        surface.configure(&device, &config);
+
+        Self { pipeline, surface, device }
+    }
+}
+
+impl WindowHandler for WgpuExample {
+    fn on_frame(&mut self, window: &mut baseview::Window) {
+        let output = self.surface.get_current_texture().unwrap();
+        let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Render Encoder"),
+        });
+
+        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("Render Pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.1, g: 0.2, b: 0.3, a: 1.0 }),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            occlusion_query_set: None,
+            timestamp_writes: None,
+        });
+
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.draw(0..3, 0..1);
+    }
+    fn on_event(
+        &mut self, window: &mut baseview::Window, event: baseview::Event,
+    ) -> baseview::EventStatus {
+        baseview::EventStatus::Captured
+    }
+}
+
+fn main() {
+    let window_open_options = WindowOpenOptions {
+        title: "wgpu on baseview".into(),
+        size: Size::new(512.0, 512.0),
+        scale: baseview::WindowScalePolicy::SystemScaleFactor,
+    };
+
+    Window::open_blocking(window_open_options, |window| {
+        pollster::block_on(WgpuExample::new(window))
+    })
+}

--- a/examples/render_wgpu/src/shader.wgsl
+++ b/examples/render_wgpu/src/shader.wgsl
@@ -1,0 +1,24 @@
+// Vertex shader
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+};
+
+@vertex
+fn vs_main(
+    @builtin(vertex_index) in_vertex_index: u32,
+) -> VertexOutput {
+    var out: VertexOutput;
+    let x = f32(1 - i32(in_vertex_index)) * 0.5;
+    let y = f32(i32(in_vertex_index & 1u) * 2 - 1) * 0.5;
+    out.clip_position = vec4<f32>(x, y, 0.0, 1.0);
+    return out;
+}
+
+// Fragment shader
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(0.3, 0.2, 0.1, 1.0);
+}
+

--- a/examples/render_wgpu/src/shader.wgsl
+++ b/examples/render_wgpu/src/shader.wgsl
@@ -1,5 +1,3 @@
-// Vertex shader
-
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) color: vec3<f32>,
@@ -19,8 +17,6 @@ fn vs_main(
     out.clip_position = vec4<f32>(model.position, 1.0);
     return out;
 }
-
-// Fragment shader
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {

--- a/examples/render_wgpu/src/shader.wgsl
+++ b/examples/render_wgpu/src/shader.wgsl
@@ -1,3 +1,5 @@
+@group(0) @binding(0) var<uniform> mouse_pos: vec2<f32>;
+
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) color: vec3<f32>,
@@ -14,7 +16,7 @@ fn vs_main(
 ) -> VertexOutput {
     var out: VertexOutput;
     out.color = model.color;
-    out.clip_position = vec4<f32>(model.position, 1.0);
+    out.clip_position = vec4<f32>(model.position.x + mouse_pos.x, model.position.y + mouse_pos.y, model.position.z, 1.0);
     return out;
 }
 

--- a/examples/render_wgpu/src/shader.wgsl
+++ b/examples/render_wgpu/src/shader.wgsl
@@ -1,17 +1,22 @@
 // Vertex shader
 
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) color: vec3<f32>,
+};
+
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: vec3<f32>,
 };
 
 @vertex
 fn vs_main(
-    @builtin(vertex_index) in_vertex_index: u32,
+    model: VertexInput,
 ) -> VertexOutput {
     var out: VertexOutput;
-    let x = f32(1 - i32(in_vertex_index)) * 0.5;
-    let y = f32(i32(in_vertex_index & 1u) * 2 - 1) * 0.5;
-    out.clip_position = vec4<f32>(x, y, 0.0, 1.0);
+    out.color = model.color;
+    out.clip_position = vec4<f32>(model.position, 1.0);
     return out;
 }
 
@@ -19,6 +24,5 @@ fn vs_main(
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    return vec4<f32>(0.3, 0.2, 0.1, 1.0);
+    return vec4<f32>(in.color, 1.0);
 }
-


### PR DESCRIPTION
this is a simple example using wgpu of a rainbow triangle that is centered at the mouse position.

it's probably not the cleanest way to do things on the wgpu side but it's a good starter example for people looking to use wgpu in baseview

some things to note:
- the wgpu version used is 0.18, this is because we needed a version that accepted a window that implements `HasRawWindowHandle` and `HasRawDisplayHandle` from rwh
- the surface size on wgpu should be twice the window size in baseview for the sizes to match up. not sure why this is, but good to note