### PR TITLE
x11: fix key modifiers mappings

### DIFF
--- a/src/x11/keyboard.rs
+++ b/src/x11/keyboard.rs
@@ -370,9 +370,9 @@ pub(super) fn key_mods(mods: KeyButMask) -> Modifiers {
         // X11's mod keys are configurable, but this seems
         // like a reasonable default for US keyboards, at least,
         // where the "windows" key seems to be MOD_MASK_4.
-        (KeyButMask::BUTTON1, Modifiers::ALT),
-        (KeyButMask::BUTTON2, Modifiers::NUM_LOCK),
-        (KeyButMask::BUTTON4, Modifiers::META),
+        (KeyButMask::MOD1, Modifiers::ALT),
+        (KeyButMask::MOD2, Modifiers::NUM_LOCK),
+        (KeyButMask::MOD4, Modifiers::META),
         (KeyButMask::LOCK, Modifiers::CAPS_LOCK),
     ];
     for (mask, modifiers) in &key_masks {


### PR DESCRIPTION
this pull request fixes a bug on x11 where ALT modifies would be triggered by holding left mouse button instead of pressing alt key (same for NUM_LOCK and META modifiers)