### PR TITLE
remove call to setMouseCoalescingEnabled on macOS

### DIFF
--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -347,8 +347,6 @@ extern "C" fn view_will_move_to_window(this: &Object, _self: Sel, new_window: id
         let tracking_areas: *mut Object = msg_send![this, trackingAreas];
         let tracking_area_count = NSArray::count(tracking_areas);
 
-        let _: () = msg_send![class!(NSEvent), setMouseCoalescingEnabled: NO];
-
         if new_window == nil {
             if tracking_area_count != 0 {
                 let tracking_area = NSArray::objectAtIndex(tracking_areas, 0);


### PR DESCRIPTION
related to https://github.com/RustAudio/baseview/issues/126

it's not clear why the line was necessary in the first place. seems like removing the line doesn't break anything, only fixes Reaper and FL Studio on macOS.