### PR TITLE
fix leak of temporary GL context on windows

### DIFF
--- a/src/gl/win.rs
+++ b/src/gl/win.rs
@@ -192,6 +192,7 @@ impl GlContext {
         };
 
         wglMakeCurrent(hdc_tmp, std::ptr::null_mut());
+        wglDeleteContext(hglrc_tmp);
         ReleaseDC(hwnd_tmp, hdc_tmp);
         UnregisterClassW(class as *const WCHAR, hinstance);
         DestroyWindow(hwnd_tmp);


### PR DESCRIPTION
Creating a modern OpenGL context on Windows requires first creating a temporary context, using it to load some function pointers (e.g. `wglCreateContextAttribsARB`), and then using those to create the actual context. In Baseview's case, the temporary context was not being deleted afterwards, resulting in a resource leak.