### PR TITLE
avoid crash when window is null in become_first_responder

### DIFF
--- a/src/gl/macos.rs
+++ b/src/gl/macos.rs
@@ -1,3 +1,7 @@
+// This is required because the objc crate is causing a lot of warnings: https://github.com/SSheldon/rust-objc/issues/125
+// Eventually we should migrate to the objc2 crate and remove this.
+#![allow(unexpected_cfgs)]
+
 use std::ffi::c_void;
 use std::str::FromStr;
 

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,3 +1,7 @@
+// This is required because the objc crate is causing a lot of warnings: https://github.com/SSheldon/rust-objc/issues/125
+// Eventually we should migrate to the objc2 crate and remove this.
+#![allow(unexpected_cfgs)]
+
 mod keyboard;
 mod view;
 mod window;

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -245,8 +245,12 @@ extern "C" fn become_first_responder(this: &Object, _sel: Sel) -> BOOL {
     let state = unsafe { WindowState::from_view(this) };
     let is_key_window = unsafe {
         let window: id = msg_send![this, window];
-        let is_key_window: BOOL = msg_send![window, isKeyWindow];
-        is_key_window == YES
+        if window != nil {
+            let is_key_window: BOOL = msg_send![window, isKeyWindow];
+            is_key_window == YES
+        } else {
+            false
+        }
     };
     if is_key_window {
         state.trigger_deferrable_event(Event::Window(WindowEvent::Focused));


### PR DESCRIPTION
apparently newer Rust versions (starting with 1.86?) have stricter debug assertions regarding unsafe code which caused a crash under debug builds because `window` was null in the `become_first_responder` method.

this fix simply checks whether `window` is null or not.