### PR TITLE
X11: Fix GL related memory leak and crash

### DIFF
--- a/src/x11/event_loop.rs
+++ b/src/x11/event_loop.rs
@@ -108,10 +108,6 @@ impl EventLoop {
 
             // Check if the parents's handle was dropped (such as when the host
             // requested the window to close)
-            //
-            // FIXME: This will need to be changed from just setting an atomic to somehow
-            // synchronizing with the window being closed (using a synchronous channel, or
-            // by joining on the event loop thread).
             if let Some(parent_handle) = &self.parent_handle {
                 if parent_handle.parent_did_drop() {
                     self.handle_must_close();


### PR DESCRIPTION
This PR fixes a memory leak caused by not releasing the GL context on X11 by calling `glXDestroyContext`, and fixes a `BadDrawable` error when closing the window in the middle of drawing by synchronizing a call to `WindowHandle::close()` with the event loop via channels.

Should fix #142 