### PR TITLE
Add screen absolute mouse position for resizing window.

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -38,8 +38,12 @@ pub enum ScrollDelta {
 pub enum MouseEvent {
     /// The mouse cursor was moved
     CursorMoved {
-        /// The logical coordinates of the mouse position
+        /// The logical coordinates of the mouse position (window-relative)
         position: Point,
+        /// The logical coordinates of the mouse position in screen space (absolute)
+        /// This remains constant even when the window resizes, making it suitable
+        /// for drag operations that resize the window.
+        screen_position: Point,
         /// The modifiers that were held down just before the event.
         modifiers: Modifiers,
     },
@@ -79,8 +83,10 @@ pub enum MouseEvent {
     CursorLeft,
 
     DragEntered {
-        /// The logical coordinates of the mouse position
+        /// The logical coordinates of the mouse position (window-relative)
         position: Point,
+        /// The logical coordinates of the mouse position in screen space (absolute)
+        screen_position: Point,
         /// The modifiers that were held down just before the event.
         modifiers: Modifiers,
         /// Data being dragged
@@ -88,8 +94,10 @@ pub enum MouseEvent {
     },
 
     DragMoved {
-        /// The logical coordinates of the mouse position
+        /// The logical coordinates of the mouse position (window-relative)
         position: Point,
+        /// The logical coordinates of the mouse position in screen space (absolute)
+        screen_position: Point,
         /// The modifiers that were held down just before the event.
         modifiers: Modifiers,
         /// Data being dragged
@@ -99,8 +107,10 @@ pub enum MouseEvent {
     DragLeft,
 
     DragDropped {
-        /// The logical coordinates of the mouse position
+        /// The logical coordinates of the mouse position (window-relative)
         position: Point,
+        /// The logical coordinates of the mouse position in screen space (absolute)
+        screen_position: Point,
         /// The modifiers that were held down just before the event.
         modifiers: Modifiers,
         /// Data being dragged

--- a/src/macos/cursor.rs
+++ b/src/macos/cursor.rs
@@ -1,0 +1,53 @@
+use crate::MouseCursor;
+use cocoa::base::id;
+use objc::{class, msg_send, sel, sel_impl};
+
+pub fn mouse_cursor_to_nscursor(cursor: MouseCursor) -> id {
+    unsafe {
+        let nscursor_class = class!(NSCursor);
+        match cursor {
+            MouseCursor::Default => msg_send![nscursor_class, arrowCursor],
+            MouseCursor::Hand => msg_send![nscursor_class, pointingHandCursor],
+            MouseCursor::HandGrabbing => msg_send![nscursor_class, closedHandCursor],
+            MouseCursor::Help => msg_send![nscursor_class, arrowCursor], // No help cursor
+            MouseCursor::Hidden => {
+                // Return a null cursor for hidden - will be handled specially
+                std::ptr::null_mut()
+            }
+            MouseCursor::Text => msg_send![nscursor_class, IBeamCursor],
+            MouseCursor::VerticalText => msg_send![nscursor_class, IBeamCursor],
+            MouseCursor::Working => msg_send![nscursor_class, arrowCursor],
+            MouseCursor::PtrWorking => msg_send![nscursor_class, arrowCursor],
+            MouseCursor::NotAllowed => msg_send![nscursor_class, operationNotAllowedCursor],
+            MouseCursor::PtrNotAllowed => msg_send![nscursor_class, operationNotAllowedCursor],
+            MouseCursor::ZoomIn => msg_send![nscursor_class, arrowCursor],
+            MouseCursor::ZoomOut => msg_send![nscursor_class, arrowCursor],
+            MouseCursor::Alias => msg_send![nscursor_class, dragLinkCursor],
+            MouseCursor::Copy => msg_send![nscursor_class, dragCopyCursor],
+            MouseCursor::Move => msg_send![nscursor_class, arrowCursor],
+            MouseCursor::AllScroll => msg_send![nscursor_class, arrowCursor],
+            MouseCursor::Cell => msg_send![nscursor_class, crosshairCursor],
+            MouseCursor::Crosshair => msg_send![nscursor_class, crosshairCursor],
+            MouseCursor::EResize => msg_send![nscursor_class, resizeRightCursor],
+            MouseCursor::NResize => msg_send![nscursor_class, resizeUpCursor],
+            MouseCursor::NeResize => msg_send![nscursor_class, arrowCursor], // No built-in
+            MouseCursor::NwResize => msg_send![nscursor_class, arrowCursor], // No built-in
+            MouseCursor::SResize => msg_send![nscursor_class, resizeDownCursor],
+            MouseCursor::SeResize => msg_send![nscursor_class, arrowCursor], // No built-in
+            MouseCursor::SwResize => msg_send![nscursor_class, arrowCursor], // No built-in
+            MouseCursor::WResize => msg_send![nscursor_class, resizeLeftCursor],
+            MouseCursor::EwResize => msg_send![nscursor_class, resizeLeftRightCursor],
+            MouseCursor::NsResize => msg_send![nscursor_class, resizeUpDownCursor],
+            MouseCursor::NwseResize => {
+                // Use private API for diagonal resize cursor
+                msg_send![nscursor_class, _windowResizeNorthWestSouthEastCursor]
+            }
+            MouseCursor::NeswResize => {
+                // Use private API for diagonal resize cursor
+                msg_send![nscursor_class, _windowResizeNorthEastSouthWestCursor]
+            }
+            MouseCursor::ColResize => msg_send![nscursor_class, resizeLeftRightCursor],
+            MouseCursor::RowResize => msg_send![nscursor_class, resizeUpDownCursor],
+        }
+    }
+}

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -2,6 +2,7 @@
 // Eventually we should migrate to the objc2 crate and remove this.
 #![allow(unexpected_cfgs)]
 
+mod cursor;
 mod keyboard;
 mod view;
 mod window;

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -334,8 +334,18 @@ impl<'a> Window<'a> {
         }
     }
 
-    pub fn set_mouse_cursor(&mut self, _mouse_cursor: MouseCursor) {
-        todo!()
+    pub fn set_mouse_cursor(&mut self, mouse_cursor: MouseCursor) {
+        let ns_cursor = crate::macos::cursor::mouse_cursor_to_nscursor(mouse_cursor);
+
+        unsafe {
+            if ns_cursor.is_null() {
+                // Hide cursor
+                let _: () = msg_send![class!(NSCursor), hide];
+            } else {
+                // Set the cursor
+                let _: () = msg_send![ns_cursor, set];
+            }
+        }
     }
 
     #[cfg(feature = "opengl")]

--- a/src/x11/event_loop.rs
+++ b/src/x11/event_loop.rs
@@ -176,10 +176,14 @@ impl EventLoop {
                 let physical_pos = PhyPoint::new(event.event_x as i32, event.event_y as i32);
                 let logical_pos = physical_pos.to_logical(&self.window.window_info);
 
+                let screen_physical_pos = PhyPoint::new(event.root_x as i32, event.root_y as i32);
+                let screen_logical_pos = screen_physical_pos.to_logical(&self.window.window_info);
+
                 self.handler.on_event(
                     &mut crate::Window::new(Window { inner: &self.window }),
                     Event::Mouse(MouseEvent::CursorMoved {
                         position: logical_pos,
+                        screen_position: screen_logical_pos,
                         modifiers: key_mods(event.state),
                     }),
                 );
@@ -194,10 +198,13 @@ impl EventLoop {
                 // we generate a CursorMoved as well, so the mouse position from here isn't lost
                 let physical_pos = PhyPoint::new(event.event_x as i32, event.event_y as i32);
                 let logical_pos = physical_pos.to_logical(&self.window.window_info);
+                let screen_physical_pos = PhyPoint::new(event.root_x as i32, event.root_y as i32);
+                let screen_logical_pos = screen_physical_pos.to_logical(&self.window.window_info);
                 self.handler.on_event(
                     &mut crate::Window::new(Window { inner: &self.window }),
                     Event::Mouse(MouseEvent::CursorMoved {
                         position: logical_pos,
+                        screen_position: screen_logical_pos,
                         modifiers: key_mods(event.state),
                     }),
                 );


### PR DESCRIPTION
Add screen-absolute mouse position and cursor setting support

### Motivation
I understand this might not be accepted due to breaking changes but as it worked so well locally I thought I'd pass it upstream just incase 😄 

When implementing custom window resize handles (or any drag operations that modify window geometry), window-relative mouse coordinates become unreliable. As the window resizes, the cursor position relative to the window constantly changes even when the mouse hasn't moved, making smooth drag calculations difficult or impossible.

### Changes

**Mouse Events - Screen Position Support:**
Added `screen_position: Point` field to:
  - `MouseEvent::CursorMoved`
  - `MouseEvent::DragEntered`
  - `MouseEvent::DragMoved`
  - `MouseEvent::DragDropped`

**macOS Cursor Support:**
- Implemented `set_mouse_cursor()` for macOS (was previously `todo!()`)
- Added new `macos/cursor.rs` module with cursor conversions
- Supports all `MouseCursor` variants including resize cursors using private `NSCursor` APIs

### Implementation Details

**macOS:**
- Uses `NSEvent::mouseLocation()` for screen coordinates
- Flips Y-axis from bottom-origin to top-origin for consistency with other platforms
- Handles both `NSView::convertPoint` (window-relative) and global mouse location

**Windows:**
- Uses `GetCursorPos()` for screen-absolute coordinates
- Converts to logical coordinates using DPI scaling
- Applied to both `WM_MOUSEMOVE` and drag events

**X11:**
- Uses `root_x`/`root_y` from X11 events (already in screen space)
- Converts to logical coordinates consistently with window-relative positions

### Breaking Changes

This is a **breaking API change**. The following enum variants now have an additional `screen_position` field:
- `MouseEvent::CursorMoved { position, screen_position, modifiers }`
- `MouseEvent::DragEntered { position, screen_position, modifiers, data }`
- `MouseEvent::DragMoved { position, screen_position, modifiers, data }`
- `MouseEvent::DragDropped { position, screen_position, modifiers, data }`

Users will need to update pattern matches, either by:
- Adding the new field: `MouseEvent::CursorMoved { position, screen_position, modifiers }`
- Using wildcard: `MouseEvent::CursorMoved { position, modifiers, .. }`

![2025-10-06 14 19 01](https://github.com/user-attachments/assets/f5f44caf-8440-4cc4-8940-cee2b40cffd6)
