### PR TITLE
Win: always link with opengl32.lib

### DIFF
--- a/src/gl/win.rs
+++ b/src/gl/win.rs
@@ -20,6 +20,12 @@ use winapi::um::winuser::{
 
 use super::{GlConfig, GlError, Profile};
 
+// winapi doesn't link with opengl32.lib on all supported Windows platforms,
+// Since winapi is no longer being maintained this is unlikely to ever be fixed,
+// so we need to link it manually.
+#[link(name = "opengl32")]
+extern "system" {}
+
 // See https://www.khronos.org/registry/OpenGL/extensions/ARB/WGL_ARB_create_context.txt
 
 type WglCreateContextAttribsARB = extern "system" fn(HDC, HGLRC, *const i32) -> HGLRC;


### PR DESCRIPTION
winapi explicitly doesn't link with opengl32.lib on all supported Windows platforms (aarch64 and thumbv7a). Presumably this dates back to when these Windows platforms didn't support OpenGL. Since that's no longer the case, and baseview won't be able to link successfully if the opengl feature is enabled and opengl32.lib isn't linked, this change makes it explicitly link opengl32.lib.