### PR TITLE
Fixed window crashes on macOS

### DIFF
--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -121,6 +121,15 @@ pub(super) unsafe fn create_view(window_options: &WindowOpenOptions) -> id {
 
     view.initWithFrame_(NSRect::new(NSPoint::new(0., 0.), NSSize::new(size.width, size.height)));
 
+    // Make the view layer-backed and attach a CAMetalLayer so Metal surfaces can be created.
+    let _: () = msg_send![view, setWantsLayer: YES];
+    let metal_layer: id = msg_send![class!(CAMetalLayer), layer];
+    let scale: f64 = msg_send![view, backingScaleFactor];
+    let bounds: NSRect = msg_send![view, bounds];
+    let _: () = msg_send![metal_layer, setContentsScale: scale];
+    let _: () = msg_send![metal_layer, setFrame: bounds];
+    let _: () = msg_send![view, setLayer: metal_layer];
+
     register_notification(view, NSWindowDidBecomeKeyNotification, nil);
     register_notification(view, NSWindowDidResignKeyNotification, nil);
 
@@ -171,6 +180,10 @@ unsafe fn create_view_class() -> &'static Class {
     class.add_method(
         sel!(viewWillMoveToWindow:),
         view_will_move_to_window as extern "C" fn(&Object, Sel, id),
+    );
+    class.add_method(
+        sel!(setFrameSize:),
+        set_frame_size as extern "C" fn(&Object, Sel, NSSize),
     );
     class.add_method(
         sel!(updateTrackingAreas:),
@@ -309,6 +322,30 @@ extern "C" fn view_did_change_backing_properties(this: &Object, _: Sel, _: id) {
         if new_window_info.physical_size() != window_info.physical_size() {
             state.window_info.set(new_window_info);
             state.trigger_event(Event::Window(WindowEvent::Resized(new_window_info)));
+        }
+
+        // Keep the metal layer in sync with scale and bounds changes.
+        let layer: id = msg_send![this, layer];
+        if layer != nil {
+            let _: () = msg_send![layer, setContentsScale: scale_factor];
+            let _: () = msg_send![layer, setFrame: bounds];
+        }
+    }
+}
+
+extern "C" fn set_frame_size(this: &Object, _sel: Sel, size: NSSize) {
+    unsafe {
+        // Call through to super to maintain default behavior
+        let superclass = msg_send![this, superclass];
+        let () = msg_send![super(this, superclass), setFrameSize: size];
+
+        // Keep the attached CAMetalLayer in sync with the view's new bounds/scale
+        let layer: id = msg_send![this, layer];
+        if layer != nil {
+            let bounds: NSRect = msg_send![this, bounds];
+            let scale: f64 = msg_send![this, backingScaleFactor];
+            let _: () = msg_send![layer, setFrame: bounds];
+            let _: () = msg_send![layer, setContentsScale: scale];
         }
     }
 }

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -149,12 +149,22 @@ impl<'a> Window<'a> {
             panic!("Not a macOS window");
         };
 
+        let parent_window = if !handle.ns_window.is_null() {
+            handle.ns_window as *mut Object
+        } else {
+            let parent_view = handle.ns_view as id;
+            unsafe {
+                let window: id = msg_send![parent_view, window];
+                window as *mut Object
+            }
+        };
+
         let ns_view = unsafe { create_view(&options) };
 
         let window_inner = WindowInner {
             open: Cell::new(true),
             ns_app: Cell::new(None),
-            ns_window: Cell::new(None),
+            ns_window: Cell::new(Some(parent_window)),
             ns_view,
 
             #[cfg(feature = "opengl")]


### PR DESCRIPTION
This was discussed on Dicord before, that the `open_parented` example crashes only on macOS build.
I also found that some gui examples in nih-plug crashes similarly because of null pointer dereference.

I finally found these issues are different problem but both are now fixed.


The problem 1:The open_parented example was crashing with a null pointer dereference when libraries like softbuffer attempted to create rendering surfaces. The crash occurred because child windows were not properly storing a reference to their parent window.

When creating a parented (child) window, the `WindowInner::ns_window` field was set to `None`.
This caused issues when external libraries called `raw_window_handle()`.
`raw_window_handle()` would return null for the `ns_window` field.
Libraries like softbuffer would receive a null window handle and crash when trying to create rendering contexts
Attempting to get the window from the view via `[ns_view window]` also returned `nil` because the view's `window` property is not immediately updated after `addSubview` is called—it only gets set after the `viewWillMoveToWindow` or `viewDidMoveToWindow` callbacks are invoked.

So `open_parented()` was modified to extract the parent window from the parent's `RawWindowHandle `and store it in the child's `WindowInner`.

The Problem 2: Applications using wgpu or other Metal-based rendering libraries were crashing when attempting to create Metal surfaces. The crash occurred in wgpu's Metal backend with the null pointer dereference.

The custom `NSView` created by baseview was not layer-backed. When wgpu's Metal backend tried to obtain the view's layer to create a Metal surface, it received `nil`.

`create_view()` in `view.rs` was modified to make views layer-backed and attach a `CAMetalLayer`.
`set_frame_size` hook is not necessary for fixing crash but it will be needed for window resizing.

to test:
Run the open_parented example on debug build; confirm no softbuffer null-pointer panic.
Run a nih-plug/examples/gain_gui_iced example on debug build.