### PR TITLE
Fix Windows OpenGL: Fail immediately when pixel format not available

### DIFF
--- a/src/gl/win.rs
+++ b/src/gl/win.rs
@@ -233,6 +233,12 @@ impl GlContext {
             &mut num_formats,
         );
 
+        if num_formats <= 0 || pixel_format == 0 {
+            eprintln!("Error: Failed to find matching pixel format (sRGB requested: {})", config.srgb);
+            ReleaseDC(hwnd, hdc);
+            return Err(GlError::CreationFailed(()));
+        }
+
         let mut pfd: PIXELFORMATDESCRIPTOR = std::mem::zeroed();
         DescribePixelFormat(
             hdc,


### PR DESCRIPTION
Previously, if the requested pixel format (including sRGB) was not available on Windows, wglChoosePixelFormatARB would return num_formats=0, but the code would proceed with an invalid pixel_format value of 0, leading to undefined behavior.

This commit adds proper validation to match Linux behavior:
- Check if wglChoosePixelFormatARB found a matching format (num_formats <= 0)
- Check if pixel_format is invalid (== 0)
- Return GlError::CreationFailed immediately if validation fails
- Properly clean up (ReleaseDC) before returning error
- Add debug message indicating the failure and whether sRGB was requested

This makes Windows behave consistently with the Linux/GLX implementation, which also fails immediately with InvalidFBConfig if the requested framebuffer configuration is not supported.