### PR TITLE
win: return HTCLIENT from WM_NCHITTEST to prevent modal resize freeze

### DIFF
--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -13,7 +13,7 @@ use winapi::um::winuser::{
     SWP_NOZORDER, TRACKMOUSEEVENT, WHEEL_DELTA, WM_CHAR, WM_CLOSE, WM_CREATE, WM_DPICHANGED,
     WM_INPUTLANGCHANGE, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN,
     WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSELEAVE, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_NCDESTROY,
-    WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SETCURSOR, WM_SHOWWINDOW, WM_SIZE, WM_SYSCHAR, WM_SYSKEYDOWN,
+    WM_NCHITTEST, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SETCURSOR, WM_SHOWWINDOW, WM_SIZE,WM_SYSCHAR, WM_SYSKEYDOWN,
     WM_SYSKEYUP, WM_TIMER, WM_USER, WM_XBUTTONDOWN, WM_XBUTTONUP, WNDCLASSW, WS_CAPTION, WS_CHILD,
     WS_CLIPSIBLINGS, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUPWINDOW, WS_SIZEBOX, WS_VISIBLE,
     XBUTTON1, XBUTTON2,
@@ -451,6 +451,11 @@ unsafe fn wnd_proc_inner(
         }
         // NOTE: `WM_NCDESTROY` is handled in the outer function because this deallocates the window
         //        state
+        WM_NCHITTEST => {
+            // Always return HTCLIENT to prevent the DAW host or Windows from
+            // entering a modal resize loop when the mouse hits window borders.
+            Some(HTCLIENT as LRESULT)
+        }
         BV_WINDOW_MUST_CLOSE => {
             DestroyWindow(hwnd);
             Some(0)


### PR DESCRIPTION
- When hosted as a VST3 child window in DAWs (Ableton, etc.), moving the mouse to the bottom/right window border while clicking causes Windows to enter a modal resize loop that freezes the entire plugin window.
- Cause: When MouseDown is active and move the mouse outside the window's border, `WM_NCHITTEST` is triggered returning `HTBOTTOM`/`HTRIGHT`/`HTBOTTOMRIGHT`
- Fix:  `wnd_proc_inner` always return `HTCLIENT` since plugin windows are embedded and should never be user-resizable via border dragging. this tells Windows the mouse is always in the client area.
- Tested in Ableton Live 12.3.1
