### PR TITLE
add default methods to WindowOpenOptions

### DIFF
--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -21,7 +21,7 @@ mod macos;
 #[cfg(target_os = "macos")]
 use macos as platform;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GlConfig {
     pub version: (u8, u8),
     pub profile: Profile,

--- a/src/window_open_options.rs
+++ b/src/window_open_options.rs
@@ -18,7 +18,7 @@ pub enum WindowScalePolicy {
 pub struct WindowOpenOptions {
     pub title: String,
 
-    /// The logical size of the window.
+    /// The logical size of the window
     ///
     /// These dimensions will be scaled by the scaling policy specified in `scale`. Mouse
     /// position will be passed back as logical coordinates.
@@ -30,21 +30,9 @@ pub struct WindowOpenOptions {
     /// If provided, then an OpenGL context will be created for this window. You'll be able to
     /// access this context through [crate::Window::gl_context].
     ///
-    /// By default this is set to `Some(GlConfig::default())`.
+    /// By default this is set to `None`.
     #[cfg(feature = "opengl")]
     pub gl_config: Option<GlConfig>,
-}
-
-impl WindowOpenOptions {
-    pub fn default_no_opengl() -> Self {
-        Self {
-            title: String::from("baseview window"),
-            size: Size { width: 500.0, height: 400.0 },
-            scale: WindowScalePolicy::default(),
-            #[cfg(feature = "opengl")]
-            gl_config: None,
-        }
-    }
 }
 
 impl Default for WindowOpenOptions {
@@ -54,7 +42,7 @@ impl Default for WindowOpenOptions {
             size: Size { width: 500.0, height: 400.0 },
             scale: WindowScalePolicy::default(),
             #[cfg(feature = "opengl")]
-            gl_config: Some(GlConfig::default()),
+            gl_config: None,
         }
     }
 }

--- a/src/window_open_options.rs
+++ b/src/window_open_options.rs
@@ -1,15 +1,20 @@
 use crate::Size;
 
+#[cfg(feature = "opengl")]
+use crate::gl::GlConfig;
+
 /// The dpi scaling policy of the window
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub enum WindowScalePolicy {
     /// Use the system's dpi scale factor
+    #[default]
     SystemScaleFactor,
     /// Use the given dpi scale factor (e.g. `1.0` = 96 dpi)
     ScaleFactor(f64),
 }
 
 /// The options for opening a new window
+#[derive(Debug, Clone, PartialEq)]
 pub struct WindowOpenOptions {
     pub title: String,
 
@@ -24,6 +29,32 @@ pub struct WindowOpenOptions {
 
     /// If provided, then an OpenGL context will be created for this window. You'll be able to
     /// access this context through [crate::Window::gl_context].
+    ///
+    /// By default this is set to `Some(GlConfig::default())`.
     #[cfg(feature = "opengl")]
-    pub gl_config: Option<crate::gl::GlConfig>,
+    pub gl_config: Option<GlConfig>,
+}
+
+impl WindowOpenOptions {
+    pub fn default_no_gl() -> Self {
+        Self {
+            title: String::from("baseview window"),
+            size: Size { width: 500.0, height: 400.0 },
+            scale: WindowScalePolicy::default(),
+            #[cfg(feature = "opengl")]
+            gl_config: None,
+        }
+    }
+}
+
+impl Default for WindowOpenOptions {
+    fn default() -> Self {
+        Self {
+            title: String::from("baseview window"),
+            size: Size { width: 500.0, height: 400.0 },
+            scale: WindowScalePolicy::default(),
+            #[cfg(feature = "opengl")]
+            gl_config: Some(GlConfig::default()),
+        }
+    }
 }

--- a/src/window_open_options.rs
+++ b/src/window_open_options.rs
@@ -36,7 +36,7 @@ pub struct WindowOpenOptions {
 }
 
 impl WindowOpenOptions {
-    pub fn default_no_gl() -> Self {
+    pub fn default_no_opengl() -> Self {
         Self {
             title: String::from("baseview window"),
             size: Size { width: 500.0, height: 400.0 },


### PR DESCRIPTION
This will fix an annoying issue I'm having in my NIH-plug fork where rust-analyzer will get confused when some crates use the "opengl" feature and some don't. I have to add special crate features just to work around it.

With this, I can just use the `..Default::default()` pattern to make both rust-analyzer and the rust compiler happy.