### PR TITLE
Fix keyboard focus for parented Windows on Windows OS

### DIFF
--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -268,6 +268,7 @@ unsafe fn wnd_proc_inner(
                         // Capture the mouse cursor on button down
                         mouse_button_counter = mouse_button_counter.saturating_add(1);
                         SetCapture(hwnd);
+                        SetFocus(hwnd);
                         MouseEvent::ButtonPressed {
                             button,
                             modifiers: window_state
@@ -691,6 +692,10 @@ impl Window<'_> {
                 null_mut(),
             );
             // todo: manage error ^
+
+            if parented {
+                SetFocus(hwnd);
+            }
 
             let kb_hook = hook::init_keyboard_hook(hwnd);
 


### PR DESCRIPTION
## Summary

This fixes keyboard focus for parented `baseview` windows on Windows.

In some embedded/parented window setups, the child window receives mouse input correctly but does not reliably receive keyboard focus. As a result, keyboard events (`WM_KEYDOWN`, `WM_CHAR`, etc.) never reach the child window, which breaks text input in embedded editors.

## Reproduction

On Windows, open a parented `baseview` window containing a text input widget.

Observed behavior:
- mouse interaction works
- the text input can be clicked
- no keyboard events reach the child window
- typing does nothing

This was reproducible in an embedded plugin editor setup using `nih-plug` / `nih_plug_iced`, and also in a minimized repro built around that stack.

## Fix

Request focus explicitly for parented windows:
- once after creating the parented window
- again on mouse button press inside the child window

This makes the child window reliably receive keyboard input after being opened and after user interaction.

## Why this helps

The issue appears to be that parented child windows do not always inherit keyboard focus reliably from the host/parent window on Windows. Explicitly calling `SetFocus(hwnd)` ensures the embedded window can receive keyboard messages.

## Notes

This change is intentionally minimal:
- it does not change keyboard event routing
- it only ensures the correct window becomes focused
- it preserves existing mouse capture behavior
