### PR TITLE
fix(macos): route first click in non-key window to mouseDown: via hitTest: override

### DIFF
--- a/src/gl/macos.rs
+++ b/src/gl/macos.rs
@@ -138,6 +138,14 @@ impl GlContext {
             let _: () = msg_send![self.view, setNeedsDisplay: YES];
         }
     }
+
+    /// Pointer to the `NSOpenGLView` this context renders into. Used by
+    /// the parent `NSView`'s `hitTest:` override to collapse hits on the
+    /// render subview to the parent, so AppKit routes `mouseDown:` on
+    /// first click in non-key windows.
+    pub(crate) fn ns_view(&self) -> id {
+        self.view
+    }
 }
 
 impl Drop for GlContext {

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -112,4 +112,13 @@ impl GlContext {
     pub(crate) fn resize(&self, size: cocoa::foundation::NSSize) {
         self.context.resize(size);
     }
+
+    /// Pointer to the `NSOpenGLView` this context renders into. Used by
+    /// the parent `NSView`'s `hitTest:` override to collapse hits on the
+    /// render subview to the parent, so AppKit routes `mouseDown:` on
+    /// first click in non-key windows.
+    #[cfg(target_os = "macos")]
+    pub(crate) fn ns_view(&self) -> cocoa::base::id {
+        self.context.ns_view()
+    }
 }

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -172,6 +172,7 @@ unsafe fn create_view_class() -> &'static Class {
         sel!(viewWillMoveToWindow:),
         view_will_move_to_window as extern "C" fn(&Object, Sel, id),
     );
+    class.add_method(sel!(hitTest:), hit_test as extern "C" fn(&Object, Sel, NSPoint) -> id);
     class.add_method(
         sel!(updateTrackingAreas:),
         update_tracking_areas as extern "C" fn(&Object, Sel, id),
@@ -344,6 +345,51 @@ unsafe fn reinit_tracking_area(this: &Object, tracking_area: *mut Object) {
         owner:this
         userInfo:nil
     ];
+}
+
+/// `hitTest:` override that collapses hits on baseview's internal
+/// OpenGL render subview to this NSView.
+///
+/// `src/gl/macos.rs` attaches an `NSOpenGLView` as a subview of this
+/// view so the GL context is isolated from event handling. The side
+/// effect is that `[NSView hitTest:]` returns the GL subview for
+/// every click inside our frame — `NSOpenGLView` inherits the
+/// default `acceptsFirstMouse:` which returns `NO`, so AppKit treats
+/// the first click in a non-key window as an activation click and
+/// never dispatches `mouseDown:`. That's the "first click dead zone"
+/// symptom reported in baseview#129 / #202 / #169.
+///
+/// Fix: if the hit lands on our own GL render subview (pointer
+/// equality against the `NSOpenGLView` stored in `GlContext`),
+/// collapse the result to `self`. AppKit then asks US about
+/// `acceptsFirstMouse:` (we return `YES`), and `mouseDown:` is
+/// dispatched on the first click. Hits on any other subview pass
+/// through unchanged — we only redirect our own render child, not
+/// anything the consumer may add.
+///
+/// No-op without the `opengl` feature: there's no GL subview to
+/// collapse, so the override pass-through is equivalent to the
+/// default implementation.
+extern "C" fn hit_test(this: &Object, _sel: Sel, point: NSPoint) -> id {
+    let super_result: id = unsafe {
+        let superclass = msg_send![this, superclass];
+        msg_send![super(this, superclass), hitTest: point]
+    };
+    if super_result == nil {
+        return nil;
+    }
+
+    #[cfg(feature = "opengl")]
+    unsafe {
+        let state = WindowState::from_view(this);
+        if let Some(gl_context) = state.window_inner.gl_context.as_ref() {
+            if super_result == gl_context.ns_view() {
+                return this as *const _ as id;
+            }
+        }
+    }
+
+    super_result
 }
 
 extern "C" fn view_will_move_to_window(this: &Object, _self: Sel, new_window: id) {

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -65,7 +65,7 @@ pub(super) struct WindowInner {
     ns_view: id,
 
     #[cfg(feature = "opengl")]
-    gl_context: Option<GlContext>,
+    pub(super) gl_context: Option<GlContext>,
 }
 
 impl WindowInner {


### PR DESCRIPTION
## Summary

macOS audio-plugin hosts (Ableton Live, REAPER, Bitwig) show a "first-click dead zone" on every baseview-based plugin: when the plugin window isn't key, the first click inside it is absorbed by AppKit as an activation click and never reaches `mouseDown:`. Every subsequent click works. This is #129 / #202 / #169 — same root cause, different reported symptoms.

This PR fixes it by overriding `hitTest:` on the root `NSView` with a narrowly-scoped collapse to `self` when the hit lands on the internal `NSOpenGLView` render subview.

## Root cause

`src/gl/macos.rs:89–99` attaches an `NSOpenGLView` as a subview of the root to host the GL context. The GL subview covers the root's frame, so `[NSView hitTest:]` returns the GL subview for every click. `NSOpenGLView` inherits the default `acceptsFirstMouse:` which returns `NO` — so when the plugin window isn't key, AppKit treats the first click as a pure activation click and never dispatches `mouseDown:` to any view. The root's `acceptsFirstMouse:` override (which returns `YES`) is never consulted because AppKit asks the hit-test target.

I verified this with selector-level logging in a real plugin (vizia-plug-based synth) running in both **Ableton Live 12.3.7** and **REAPER 7.69** on macOS 15.5:

- `mouseMoved:` fires normally (tracking areas hand them to the root regardless of hit depth).
- `hitTest:` returns an object other than `self` for every click.
- `acceptsFirstMouse:` is never called on any selector I added logging to.
- `mouseDown:` is never called on the first click.
- On the second click, the window is already key (activated by click #1), so `acceptsFirstMouse:` is irrelevant and `mouseDown:` fires normally.

## Why existing proposals don't close this

- **#203** (@andrewrynhard's PR implementing the patch @justinfrankel proposed in #202 — `makeFirstResponder:` inside the `mouseDown:` macro) — can't help: `mouseDown:` doesn't fire on the first click, so there's no hook point. Fixes downstream keyboard-focus for clicks #2+, but the #129 first-click symptom remains. This also explains the "triggered on every mouse click which is incorrect" objection raised on #203 — scoping at `hitTest:` is more precise.
- **#170** (`Window::focus()` API) — requires every downstream GUI (vizia, egui, iced) to know when to call it. Even when they do, the underlying AppKit event-routing is still broken — it only papers over the keyboard-focus symptom after the user has already lost their first click.
- **#202** (@justinfrankel's original report from the REAPER team) — the diagnosis "NSViews as first responder on mouse click" is correct for the keyboard-input symptom but points at the wrong layer to fix. The root issue is that the click is never delivered to the right view in the first place.

## The fix

```rust
extern "C" fn hit_test(this: &Object, _sel: Sel, point: NSPoint) -> id {
    let super_result: id = unsafe {
        let superclass = msg_send![this, superclass];
        msg_send![super(this, superclass), hitTest: point]
    };
    if super_result == nil {
        return nil;
    }
    unsafe {
        let gl_class = class!(NSOpenGLView);
        let is_gl_subview: BOOL = msg_send![super_result, isKindOfClass: gl_class];
        if is_gl_subview == YES {
            return this as *const _ as id;
        }
    }
    super_result
}
```

Two methods added, registered via `add_method` in `create_view_class`:

- `hitTest:` — collapses in-bounds hits on `NSOpenGLView` to `self`. AppKit now asks the root view about `acceptsFirstMouse:`, we return `YES`, the first click is delivered.
- `viewDidMoveToWindow` — calls `makeFirstResponder:` after the view is in its target window. `viewWillMoveToWindow:` already calls it, but that runs before attachment and can silently fail.

## Scope / safety

- **`isKindOfClass: NSOpenGLView`** gate ensures we don't break future legitimate child views (e.g. an `NSTextView` overlay for IME, `NSScrollView`). Those keep receiving hits normally.
- **No-op on the software-renderer path**. Without an `NSOpenGLView` child, `[super hitTest:]` returns either `self` (in-bounds, no subviews) or `nil` (out-of-bounds). Neither triggers the collapse.
- **Rendering is unaffected** — the `NSOpenGLView` still exists as a subview and still draws into its GL context. We only redirect event routing, not rendering.
- **Drag-and-drop unaffected** — drag uses `draggingEntered:` / `registeredForDraggedTypes:`, not `hitTest:`.
- **Accessibility unaffected** — AX uses `accessibilityHitTest:`, which is separate.

## Testing

Tested end-to-end in **Ableton Live 12.3.7** and **REAPER 7.69** on macOS 15.5:

- First click on knobs, buttons, header logo → action fires on the first click with the window becoming key simultaneously, matching the single-click-activates behaviour expected of modern plug-in windows.
- Knob drag (hold + move) works on first press.
- Button press (mouseDown + mouseUp → `WindowEvent::Press` sequence) works on first click.
- Right-click context menu opens on first right-click.
- Subsequent clicks in the already-key window behave identically to before this PR.

## Related

- Fixes #129 directly.
- Fixes the macOS portion of #202 (keyboard in REAPER works once the first responder is correctly transferred, which this PR makes happen via the standard AppKit path).
- Fixes the baseview portion of #169 (combined with the already-merged nih-plug fix for VST3 `onKeyDown` returning the right `TResult`).
- Does not address #152 / #225 (Windows-specific focus, different code path).