### PR TITLE
fix(macos): don't panic on unexpected event types in keyboard callbacks

### DIFF
--- a/src/macos/keyboard.rs
+++ b/src/macos/keyboard.rs
@@ -311,7 +311,18 @@ impl KeyboardState {
                         return None;
                     }
                 }
-                _ => unreachable!(),
+                // AppKit occasionally dispatches non-key events into
+                // `keyDown:` / `keyUp:` / `flagsChanged:` selectors
+                // (e.g. `NSAppKitDefined`, `NSSystemDefined`, or sync
+                // events around Cmd-Tab and input-source switches).
+                // Panicking here crosses the `extern "C"` boundary as
+                // `panic_cannot_unwind` and aborts the hosting process,
+                // which has been observed crashing plug-in hosts when
+                // the focused view is a baseview `NSView`. Drop the
+                // event silently instead; the handler has nothing
+                // meaningful to synthesize from an event that isn't
+                // a key or flags-changed.
+                _ => return None,
             };
             let is_composing = false;
             let repeat: bool = event_type == NSEventType::NSKeyDown && msg_send![event, isARepeat];


### PR DESCRIPTION
## Summary

`KeyboardState::process_native_event` (`src/macos/keyboard.rs:282`) is called from the macro-generated `keyDown:` / `keyUp:` / `flagsChanged:` selector implementations in `src/macos/view.rs:77`. The `match event.eventType()` in the function only covers `NSKeyDown`, `NSKeyUp`, and `NSFlagsChanged`, falling through to `_ => unreachable!()` for anything else.

Because the selector functions are generated as `extern "C"`, hitting `unreachable!()` crosses the FFI boundary as `panic_cannot_unwind` and aborts the hosting process. For plug-ins, that crashes the DAW.

## Evidence

Captured from a baseview-based plug-in running in Ableton Live 12.3.6 on macOS, 2026-04-24:

```
info:     panicked at library/core/src/panicking.rs:225:5:
panic in a function that cannot unwind
backtrace:
  ...
 10: core::panicking::panic_nounwind_fmt::runtime
 11: core::panicking::panic_nounwind_fmt
 12: core::panicking::panic_nounwind
 13: core::panicking::panic_cannot_unwind
 14: flagsChanged
           at src/macos/view.rs:81:9
 15: <unknown>
 16: <unknown>
```

(The inner panic frame that actually tripped `unreachable!()` was optimized out; frame 14 is the FFI boundary function. Given the match structure, the unreachable is the candidate.)

## Why this hits in practice

AppKit occasionally dispatches non-key events into the key selectors during Cmd-Tab transitions, input-source switches, modifier-repeat sequences, and sleep/wake cycles. Even if the specific crash above was not `unreachable!()` itself, any unexpected `NSEvent::eventType()` value (`NSAppKitDefined`, `NSSystemDefined`, etc.) reaching this function is a latent crash.

## Fix

Replace `_ => unreachable!()` with `_ => return None`. The handler silently drops events it cannot interpret. There is nothing meaningful to synthesize from an event that is not a key or flags-changed, and panicking from an `extern "C"` callback is never the right move.

The `NSFlagsChanged` arm above this already has a `return None` branch for the non-modifier-key subcase (line 311 on master), so the return-None fallback is consistent with existing handling of uninteresting events.

## Test plan

- [x] `cargo check --features opengl` green.
- [x] Verified on a baseview-based plugin in both Ableton Live 12.3.6 and REAPER 7.69 on macOS 15.5: normal typing, backspace, enter, arrow keys, modifier combinations, Cmd-Tab in and out, input-source switch, all unchanged. No new crashes observed.

Local CI notes: the `cargo fmt --check` and `cargo clippy -D warnings` errors on `master` appear to be pre-existing (upstream `objc 0.2.7`'s `cargo-clippy` cfg warnings and a `window.rs` formatting drift that I did not touch). Happy to adjust scope if you want the cfg-warning suppression bundled into this PR or handled separately.
