### PR TITLE
ci: register cargo-clippy cfg to silence objc 0.2.7 macro warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(feature, values(\"cargo-clippy\"))");
+}


### PR DESCRIPTION
## Summary

The `objc` 0.2.7 crate's `msg_send!` / `class!` / `sel_impl!` macros emit `#[cfg(feature = "cargo-clippy")]` in their expansion. Because macros expand at the call site, the cfg lands in baseview's own compilation unit, where `cargo`'s default `--cap-lints=allow` for registry dependencies does not apply. CI's `RUSTFLAGS=-D warnings` then promotes the resulting `unexpected_cfgs` lint to a hard error: 100+ identical errors per `msg_send!` site, breaking the macOS job.

## Fix

Three lines in a new `build.rs` registering the cfg as expected:

```rust
fn main() {
    println!("cargo:rustc-check-cfg=cfg(feature, values(\"cargo-clippy\"))");
}
```

This tells rustc that `feature = "cargo-clippy"` is a valid cfg expectation in baseview's own translation unit, so the lint stops firing during baseview's compilation. Dependencies are unaffected.

## Why this works (macro-expansion specifics)

Trace from a failing build, slightly trimmed:

```
Compiling objc v0.2.7 ... --cap-lints allow -D warnings
Compiling cocoa v0.24.1 ... --cap-lints allow -D warnings
Compiling baseview ... -D warnings
error: unexpected `cfg` condition value: `cargo-clippy`
    = note: this error originates in the macro `sel_impl` which comes from
      the expansion of the macro `msg_send` (in Nightly builds, run with
      -Z macro-backtrace for more info)
```

The error fires while compiling **baseview**, not `objc`. Cargo's `--cap-lints=allow` flag only applies to the dep's own translation unit; macros that the dep exports drag the offending cfg into the consumer's compilation, where `--cap-lints` doesn't help. `cargo:rustc-check-cfg` from baseview's `build.rs` registers the expected cfg specifically in baseview's lint pass, which is exactly where the warning lands.

## Verified locally

On macOS 15 (Apple Silicon), stable Rust:

| Command | Without build.rs | With build.rs |
|---|---|---|
| `RUSTFLAGS="-D warnings" cargo build --workspace --all-targets` | 118 errors, fails | exit 0 |
| `RUSTFLAGS="-D warnings" cargo build --workspace --all-targets --all-features` | fails | exit 0 |
| `RUSTFLAGS="-D warnings" cargo test --workspace --all-targets --all-features --no-run` | fails | exit 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc --examples --all-features --no-deps` | fails | exit 0 |

Mirrors the failing CI workflow exactly.

## Relation to the longer-term fixes

Pure CI unblock; does not address the root cause. The proper fixes (publish `objc` 0.2.8 with #SSheldon/rust-objc#125's merged fix, or migrate baseview to `objc2`) remain orthogonal to this PR and can be pursued on their own timelines. This is just to keep the macOS job green in the meantime so other PRs (e.g. #228) can merge.
