### PR TITLE
move #![allow(unexpected_cfgs)] to crate root

### DIFF
--- a/src/gl/macos.rs
+++ b/src/gl/macos.rs
@@ -1,7 +1,3 @@
-// This is required because the objc crate is causing a lot of warnings: https://github.com/SSheldon/rust-objc/issues/125
-// Eventually we should migrate to the objc2 crate and remove this.
-#![allow(unexpected_cfgs)]
-
 use std::ffi::c_void;
 use std::str::FromStr;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+// This is required because the objc crate is causing a lot of warnings: https://github.com/SSheldon/rust-objc/issues/125
+// Eventually we should migrate to the objc2 crate and remove this.
+#![allow(unexpected_cfgs)]
+
 #[cfg(target_os = "macos")]
 mod macos;
 #[cfg(target_os = "windows")]

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,7 +1,3 @@
-// This is required because the objc crate is causing a lot of warnings: https://github.com/SSheldon/rust-objc/issues/125
-// Eventually we should migrate to the objc2 crate and remove this.
-#![allow(unexpected_cfgs)]
-
 mod keyboard;
 mod view;
 mod window;

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -11,7 +11,7 @@ use cocoa::appkit::{
 use cocoa::base::{id, nil, BOOL, NO, YES};
 use cocoa::foundation::{NSAutoreleasePool, NSPoint, NSRect, NSSize, NSString};
 use core_foundation::runloop::{
-    CFRunLoop, CFRunLoopTimer, CFRunLoopTimerContext, __CFRunLoopTimer, kCFRunLoopDefaultMode,
+    __CFRunLoopTimer, kCFRunLoopDefaultMode, CFRunLoop, CFRunLoopTimer, CFRunLoopTimerContext,
 };
 use keyboard_types::KeyboardEvent;
 use objc::class;


### PR DESCRIPTION
CI builds are failing due to warnings caused by macros from the `objc` crate (`msg_send!`, `sel!`, and `class!`). The existing module-level `#![allow(unexpected_cfgs)]` attributes apparently no longer work to silence these warnings, but moving the attribute to the crate root seems to work.

Fixes #229.

Also run `cargo fmt` so that formatting check passes.