### PR TITLE
Explicitly state in the README that the RustAudio community's AI policies applies to this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Install dependencies, e.g.:
 sudo apt-get install libx11-dev libxcb1-dev libx11-xcb-dev libgl1-mesa-dev
 ```
 
+## Contributing
+
+Contributions are very much welcomed! As long as they comply to the policy and licensing requirements
+below.
+
+### AI policy
+
+The general [AI policy of the RustAudio Community](https://rust.audio/community/ai/) applies to this repository. Please
+ensure compliance to these rules before submitting your contribution to this project.
+
 ## License
 
 Licensed under either of <a href="LICENSE-APACHE">Apache License, Version


### PR DESCRIPTION
The [AI policy of the RustAudio Community](https://rust.audio/community/ai/) already applies to this repository by default, so this does not change any actual policy.

However, this policy is currently not easy to find when coming from this repository (you have to find the Discord link in the RustAudio org's bio and then find the policy in the Discord server's internal rules). So I made it explicit by linking to it directly with the README, with no other changes.