### PR TITLE
macOS: Set ns_window to the parent window when creating WindowHandles

### DIFF
--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -113,9 +113,9 @@ impl WindowInner {
 
     fn raw_window_handle(&self) -> RawWindowHandle {
         if self.open.get() {
-            let ns_window = self.ns_window.get()
-                .or(self.parent_ns_window)
-                .unwrap_or(ptr::null_mut()) as *mut c_void;
+            let ns_window =
+                self.ns_window.get().or(self.parent_ns_window).unwrap_or(ptr::null_mut())
+                    as *mut c_void;
 
             let mut handle = AppKitWindowHandle::empty();
             handle.ns_window = ns_window;

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -61,6 +61,10 @@ pub(super) struct WindowInner {
     /// Only set if we created the parent window, i.e. we are running in
     /// parentless mode
     ns_window: Cell<Option<id>>,
+
+    /// Only set when running in parented mode.
+    parent_ns_window: Option<id>,
+
     /// Our subclassed NSView
     ns_view: id,
 
@@ -109,7 +113,9 @@ impl WindowInner {
 
     fn raw_window_handle(&self) -> RawWindowHandle {
         if self.open.get() {
-            let ns_window = self.ns_window.get().unwrap_or(ptr::null_mut()) as *mut c_void;
+            let ns_window = self.ns_window.get()
+                .or(self.parent_ns_window)
+                .unwrap_or(ptr::null_mut()) as *mut c_void;
 
             let mut handle = AppKitWindowHandle::empty();
             handle.ns_window = ns_window;
@@ -155,6 +161,11 @@ impl<'a> Window<'a> {
             open: Cell::new(true),
             ns_app: Cell::new(None),
             ns_window: Cell::new(None),
+            parent_ns_window: if handle.ns_window.is_null() {
+                None
+            } else {
+                Some(handle.ns_window.cast())
+            },
             ns_view,
 
             #[cfg(feature = "opengl")]
@@ -230,6 +241,7 @@ impl<'a> Window<'a> {
             open: Cell::new(true),
             ns_app: Cell::new(Some(app)),
             ns_window: Cell::new(Some(ns_window)),
+            parent_ns_window: None,
             ns_view,
 
             #[cfg(feature = "opengl")]


### PR DESCRIPTION
Currently, when baseview creates a window in parented mode, the `WindowHandle`s it gives out have their `ns_window` field set to `null`, which makes some downstream libraries (such as `softbuffer`) crash.

This means the `open_parented` example completely crashes as a result, it does not even start properly on macOS.

This PR fixes this by storing the parent `NSWindow` pointer separately, and then using it to set the `WindowHandle`'s `ns_window` field.

I can confirm it prevents the crash on macOS 26.2.

This PR supersedes the fix in #219. Unlike in that PR, this PR stores the parent `NSWindow` pointer separately, so it does not impact other baseview operations.