### PR TITLE
Explicitly set MSRV to 1.80

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,16 +9,16 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
+        toolchain: [ "1.64", stable, beta, nightly ]
     runs-on: ${{ matrix.os }}
     env:
       RUSTFLAGS: -D warnings
-      RUSTDOCFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v6
       - name: Install rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           components: clippy
       - name: Build Default
         run: cargo build --workspace --all-targets --verbose
@@ -42,5 +42,3 @@ jobs:
           components: rustfmt
       - name: Check docs
         run: cargo doc --all --all-features --no-deps
-      - name: Check Formatting (rustfmt)
-        run: cargo fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        toolchain: [ "1.64", stable, beta, nightly ]
+        toolchain: [ "1.64", stable ]
     runs-on: ${{ matrix.os }}
     env:
       RUSTFLAGS: -D warnings
@@ -21,11 +21,14 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
       - name: Build Default
-        run: cargo build --workspace --all-targets --verbose
+        run: cargo build -p baseview --verbose
       - name: Build All Features
-        run: cargo build --workspace --all-targets --all-features --verbose
+        run: cargo build -p baseview --all-features --verbose
       - name: Run tests
-        run: cargo test --workspace --all-targets --all-features --verbose
+        run: cargo test -p baseview --all-features --verbose
+      - name: Build examples
+        if: matrix.toolchain != '1.64'
+        run: cargo build --workspace --all-targets --verbose
       - name: Clippy
         run: cargo clippy --all --all-features -- -D warnings
   checks:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,7 @@ jobs:
         if: matrix.toolchain != '1.80'
         run: cargo build --workspace --all-targets --verbose
       - name: Clippy
+        if: matrix.toolchain != '1.80'
         run: cargo clippy --all --all-features -- -D warnings
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        toolchain: [ "1.71", stable ]
+        toolchain: [ "1.80", stable ]
     runs-on: ${{ matrix.os }}
     env:
       RUSTFLAGS: -D warnings
@@ -27,7 +27,7 @@ jobs:
       - name: Run tests
         run: cargo test -p baseview --all-features --verbose
       - name: Build examples
-        if: matrix.toolchain != '1.71'
+        if: matrix.toolchain != '1.80'
         run: cargo build --workspace --all-targets --verbose
       - name: Clippy
         run: cargo clippy --all --all-features -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        toolchain: [ "1.64", stable ]
+        toolchain: [ "1.65", stable ]
     runs-on: ${{ matrix.os }}
     env:
       RUSTFLAGS: -D warnings
@@ -27,7 +27,7 @@ jobs:
       - name: Run tests
         run: cargo test -p baseview --all-features --verbose
       - name: Build examples
-        if: matrix.toolchain != '1.64'
+        if: matrix.toolchain != '1.65'
         run: cargo build --workspace --all-targets --verbose
       - name: Clippy
         run: cargo clippy --all --all-features -- -D warnings
@@ -45,3 +45,5 @@ jobs:
           components: rustfmt
       - name: Check docs
         run: cargo doc --all --all-features --no-deps
+      - name: Clippy
+        run: cargo clippy --all --all-features -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        toolchain: [ "1.65", stable ]
+        toolchain: [ "1.71", stable ]
     runs-on: ${{ matrix.os }}
     env:
       RUSTFLAGS: -D warnings
@@ -27,7 +27,7 @@ jobs:
       - name: Run tests
         run: cargo test -p baseview --all-features --verbose
       - name: Build examples
-        if: matrix.toolchain != '1.65'
+        if: matrix.toolchain != '1.71'
         run: cargo build --workspace --all-targets --verbose
       - name: Clippy
         run: cargo clippy --all --all-features -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,5 +45,5 @@ jobs:
           components: rustfmt
       - name: Check docs
         run: cargo doc --all --all-features --no-deps
-      - name: Clippy
-        run: cargo clippy --all --all-features -- -D warnings
+      - name: Check Formatting (rustfmt)
+        run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["gui"]
 repository = "https://github.com/RustAudio/baseview"
 
 exclude = [".github"]
-rust-version = "1.71"
+rust-version = "1.80"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ categories = ["gui"]
 repository = "https://github.com/RustAudio/baseview"
 
 exclude = [".github"]
+rust-version = "1.64.0"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["gui"]
 repository = "https://github.com/RustAudio/baseview"
 
 exclude = [".github"]
-rust-version = "1.64.0"
+rust-version = "1.65"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["gui"]
 repository = "https://github.com/RustAudio/baseview"
 
 exclude = [".github"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [features]
 default = []


### PR DESCRIPTION
This is based on the most recent feature we are currently using (`LazyLock`).

This PR does not actually change the de-facto MSRV of baseview, it only makes it explicit, and adds CI checks to make sure it is not unwillingly changed in the future.