### PR TITLE
macOS: Use CFUUID instead of the uuid crate for a random class name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,8 @@ winapi = { version = "0.3.8", features = ["libloaderapi", "winuser", "windef", "
 uuid = { version = "0.8", features = ["v4"], optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
-uuid = { version = "1.23.1", features = ["v4"] }
 objc2 = "0.6.4"
-objc2-core-foundation = { version = "0.3.2", default-features = false, features = ["std", "CFString"] }
+objc2-core-foundation = { version = "0.3.2", default-features = false, features = ["std", "CFString", "CFUUID"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSEnumerator"] }
 objc2-app-kit = { version = "0.3.2", default-features = false, features = [
     "NSApplication",

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -124,7 +124,9 @@ pub(super) fn create_view(window_options: &WindowOpenOptions) -> Retained<NSView
 }
 
 fn new_class_name() -> CString {
+    // PANIC: CFUUIDCreate is not documented to return NULL.
     let uuid = CFUUID::new(None).unwrap();
+    // PANIC: CFUUIDCreateString is not documented to return NULL.
     let uuid_str = CFUUID::new_string(None, Some(&uuid)).unwrap();
 
     let class_name = format!("BaseviewNSView_{uuid_str}");

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -12,11 +12,11 @@ use objc2_app_kit::{
     NSTrackingAreaOptions, NSView, NSWindow, NSWindowDidBecomeKeyNotification,
     NSWindowDidResignKeyNotification,
 };
+use objc2_core_foundation::CFUUID;
 use objc2_foundation::{
     NSArray, NSNotification, NSNotificationCenter, NSPoint, NSRect, NSSize, NSString,
 };
 use std::ffi::{c_void, CStr, CString};
-use uuid::Uuid;
 
 use super::keyboard::make_modifiers;
 use super::window::WindowState;
@@ -123,6 +123,15 @@ pub(super) fn create_view(window_options: &WindowOpenOptions) -> Retained<NSView
     view
 }
 
+fn new_class_name() -> CString {
+    let uuid = CFUUID::new(None).unwrap();
+    let uuid_str = CFUUID::new_string(None, Some(&uuid)).unwrap();
+
+    let class_name = format!("BaseviewNSView_{uuid_str}");
+    // PANIC: This cannot have any NULL bytes
+    CString::new(class_name).unwrap()
+}
+
 /// # Safety
 ///
 /// This class is going to be destroyed when its first instance gets deallocated.
@@ -134,9 +143,7 @@ unsafe fn create_view_class() -> &'static AnyClass {
     // the class was stored in a OnceCell after creation. This way, we didn't
     // have to recreate it each time a view was opened, but now we don't leave
     // any class definitions lying around when the plugin is closed.
-    let class_name = CString::new(format!("BaseviewNSView_{}", Uuid::new_v4().simple()))
-        // PANIC: This cannot have any NULL bytes
-        .unwrap();
+    let class_name = new_class_name();
 
     let mut class = ClassBuilder::new(&class_name, NSView::class()).unwrap();
 


### PR DESCRIPTION
This PR replaces the use of the `uuid` crate with the Core Foundation [`CFUUID`](https://developer.apple.com/documentation/corefoundation/cfuuid) API, when creating a random class name for our `NSView` class.

This allows us to drop the `uuid` dependency (at least on macOS), while keeping the same functionality.

Note that the [`CFUUID`](https://developer.apple.com/documentation/corefoundation/cfuuid) APIs currently generate a UUIDv4, which is equivalent to our current implementation.

However, even if that were to change, any UUID version (time-based, random-based, or any mix of both) works for our use-case of avoiding runtime namespace collisions between plugins and the host.

This use-case actually being what the `CFUUID` API is built for, this will still work long-term.