### PR TITLE
Windows: Fix DND on non-parented windows (bugfix)

### DIFF
--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -512,7 +512,7 @@ pub(super) struct WindowState {
     window_class: Cell<Option<RegisteredClass>>,
     current_size: Cell<PhySize>,
     current_scale_factor: Cell<f64>,
-    _parent_handle: Option<ParentHandle>,
+    _parent_handle: ParentHandle,
     keyboard_state: RefCell<KeyboardState>,
     mouse_button_counter: Cell<usize>,
     mouse_was_outside_window: RefCell<bool>,
@@ -632,7 +632,7 @@ impl Window<'_> {
         B: FnOnce(&mut crate::Window) -> H,
         B: Send + 'static,
     {
-        let (_, _) = Self::open(false, null_mut(), options, build);
+        let (window_handle, _) = Self::open(false, null_mut(), options, build);
 
         unsafe {
             let mut msg: MSG = std::mem::zeroed();
@@ -646,6 +646,10 @@ impl Window<'_> {
 
                 TranslateMessage(&msg);
                 DispatchMessageW(&msg);
+
+                if !window_handle.is_open() {
+                    break;
+                }
             }
         }
     }
@@ -725,7 +729,6 @@ impl Window<'_> {
             });
 
             let (parent_handle, window_handle) = ParentHandle::new(hwnd);
-            let parent_handle = if parented { Some(parent_handle) } else { None };
 
             let window_state = Rc::new(WindowState {
                 hwnd,

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -632,13 +632,13 @@ impl Window<'_> {
         B: FnOnce(&mut crate::Window) -> H,
         B: Send + 'static,
     {
-        let (_, hwnd) = Self::open(false, null_mut(), options, build);
+        let (_, _) = Self::open(false, null_mut(), options, build);
 
         unsafe {
             let mut msg: MSG = std::mem::zeroed();
 
             loop {
-                let status = GetMessageW(&mut msg, hwnd, 0, 0);
+                let status = GetMessageW(&mut msg, null_mut(), 0, 0);
 
                 if status == -1 {
                     break;


### PR DESCRIPTION
Hi Rustaudio, I'm opening up a slew of PRs so I figured I'd provide a small preamble for this first one. I had forked baseview years ago and quickly diverged enough that I never wound up trying to submit anything upstream. With the 0.1 release I finally decided get on board and contribute back.

The majority of these are relatively small bugfixes for Windows, though a few are new features – The PR descriptions will indicate what the contents contain.

Thanks in advance for the reviews!

***

Filtering GetMessageW to hwnd precludes getting events from the OLE thread that's handling the DND. In practice this means that when dragging something into the baseview window, the drag process (that OLE thread) freezes up, making it impossible to complete the drag.