### PR TITLE
Windows: Don't call GetMessageW after window has closed (bugfix)

### DIFF
--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -609,6 +609,11 @@ impl Window<'_> {
             let mut msg: MSG = std::mem::zeroed();
 
             loop {
+                let window_state_ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut WindowState;
+                if window_state_ptr.is_null() {
+                    break;
+                }
+
                 let status = GetMessageW(&mut msg, hwnd, 0, 0);
 
                 if status == -1 {


### PR DESCRIPTION
This fixes an occasional panic: sometimes we'll re-enter the message-handling loop after a window has been closed, and GetMessageW will fail.