### PR TITLE
Windows: defer SetFocus tasks (bugfix)

### DIFF
--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -586,6 +586,9 @@ impl WindowState {
                     )
                 };
             }
+            WindowTask::Focus => unsafe {
+                SetFocus(self.hwnd);
+            },
         }
     }
 }
@@ -597,6 +600,8 @@ pub(super) enum WindowTask {
     /// Resize the window to the given size. The size is in logical pixels. DPI scaling is applied
     /// automatically.
     Resize(Size),
+    /// Request keyboard focus for the window.
+    Focus,
 }
 
 pub struct Window<'a> {
@@ -828,9 +833,9 @@ impl Window<'_> {
     }
 
     pub fn focus(&mut self) {
-        unsafe {
-            SetFocus(self.state.hwnd);
-        }
+        // To avoid reentrant event handler calls we'll defer the actual focus request until after
+        // the event has been handled
+        self.state.deferred_tasks.borrow_mut().push_back(WindowTask::Focus);
     }
 
     pub fn resize(&mut self, size: Size) {


### PR DESCRIPTION
Otherwise, a panic will occur when calling `Window.focus` while handling events (e.g. when clicking on the nice-plug egui or iced examples)