### PR TITLE
Add `WindowOpenOptions.resizable` (feature)

### DIFF
--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -224,14 +224,20 @@ impl<'a> Window<'a> {
 
             let window_info = WindowInfo::from_logical_size(options.size, scaling);
 
+            let mut style_mask = NSWindowStyleMask::Titled
+                | NSWindowStyleMask::Closable
+                | NSWindowStyleMask::Miniaturizable;
+
+            if options.resizable {
+                style_mask |= NSWindowStyleMask::Resizable;
+            }
+
             // SAFETY: This is safe because of the setReleasedWhenClosed(false) below
             let ns_window = unsafe {
                 NSWindow::initWithContentRect_styleMask_backing_defer(
                     NSWindow::alloc(mtm),
                     rect,
-                    NSWindowStyleMask::Titled
-                        | NSWindowStyleMask::Closable
-                        | NSWindowStyleMask::Miniaturizable,
+                    style_mask,
                     NSBackingStoreType::Buffered,
                     false,
                 )

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -652,17 +652,15 @@ impl Window<'_> {
                 bottom: current_size.height as i32,
             };
 
-            let flags = if parented {
+            let mut flags = if parented {
                 WS_CHILD | WS_VISIBLE
             } else {
-                WS_POPUPWINDOW
-                    | WS_CAPTION
-                    | WS_VISIBLE
-                    | WS_SIZEBOX
-                    | WS_MINIMIZEBOX
-                    | WS_MAXIMIZEBOX
-                    | WS_CLIPSIBLINGS
+                WS_POPUPWINDOW | WS_CAPTION | WS_VISIBLE | WS_MINIMIZEBOX | WS_CLIPSIBLINGS
             };
+
+            if !parented && options.resizable {
+                flags |= WS_SIZEBOX | WS_MAXIMIZEBOX;
+            }
 
             if !parented {
                 AdjustWindowRectEx(&mut rect, flags, FALSE, 0);

--- a/src/window_open_options.rs
+++ b/src/window_open_options.rs
@@ -27,6 +27,9 @@ pub struct WindowOpenOptions {
     /// The dpi scaling policy
     pub scale: WindowScalePolicy,
 
+    /// Should this window be resizable?
+    pub resizable: bool,
+
     /// If provided, then an OpenGL context will be created for this window. You'll be able to
     /// access this context through [crate::Window::gl_context].
     ///
@@ -59,6 +62,12 @@ impl WindowOpenOptions {
         self
     }
 
+    #[inline]
+    pub fn with_resizable(mut self, resizable: bool) -> Self {
+        self.resizable = resizable;
+        self
+    }
+
     #[cfg(feature = "opengl")]
     #[inline]
     pub fn with_gl_config(mut self, gl_config: impl Into<Option<GlConfig>>) -> Self {
@@ -73,6 +82,7 @@ impl Default for WindowOpenOptions {
             title: String::from("baseview window"),
             size: Size { width: 500.0, height: 400.0 },
             scale: WindowScalePolicy::default(),
+            resizable: true,
             #[cfg(feature = "opengl")]
             gl_config: None,
         }

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -13,6 +13,7 @@ use raw_window_handle::{
 };
 
 use x11rb::connection::Connection;
+use x11rb::properties::WmSizeHints;
 use x11rb::protocol::xproto::{
     AtomEnum, ChangeWindowAttributesAux, ConfigureWindowAux, ConnectionExt as _, CreateGCAux,
     CreateWindowAux, EventMask, PropMode, Visualid, Window as XWindow, WindowClass,
@@ -250,6 +251,18 @@ impl<'a> Window<'a> {
             AtomEnum::ATOM,
             &[xcb_connection.atoms.WM_DELETE_WINDOW],
         )?;
+
+        if !options.resizable {
+            let width = window_info.physical_size().width as i32;
+            let height = window_info.physical_size().height as i32;
+
+            WmSizeHints {
+                min_size: Some((width, height)),
+                max_size: Some((width, height)),
+                ..Default::default()
+            }
+            .set_normal_hints(xcb_connection.conn.xcb_connection(), window_id)?;
+        }
 
         xcb_connection.conn.flush()?;
         let xcb_connection = Rc::new(xcb_connection);


### PR DESCRIPTION
This adds a new `WindowOpenOptions`, allowing the user to specify when a window should not be resizable (on all platforms). The default behaviour (`resizable: true`) is unchanged.