### PR TITLE
Initiate Drag events (feature: Windows and OSX)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,12 @@ nix = "0.22.0"
 windows = { version = "=0.61.3", features = [
     "Win32_Graphics_Gdi",
     "Win32_Graphics_OpenGL",
+    "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",
+    "Win32_System_Memory",
     "Win32_System_Ole",
     "Win32_System_SystemServices",
+    "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
 ] }
 windows-sys = { version = "0.61.2", features = [
@@ -71,12 +74,16 @@ uuid = { version = "0.8", features = ["v4"], optional = true }
 [target.'cfg(target_os="macos")'.dependencies]
 objc2 = "0.6.4"
 objc2-core-foundation = { version = "0.3.2", default-features = false, features = ["std", "CFString", "CFUUID"] }
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSEnumerator"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSEnumerator", "NSURL"] }
 objc2-app-kit = { version = "0.3.2", default-features = false, features = [
     "NSApplication",
+    "NSColor",
     "NSDragging",
+    "NSDraggingItem",
+    "NSDraggingSession",
     "NSEvent",
     "NSGraphics",
+    "NSImage",
     "NSPasteboard",
     "NSResponder",
     "NSRunningApplication",

--- a/src/macos/view.rs
+++ b/src/macos/view.rs
@@ -6,11 +6,11 @@ use objc2::rc::Allocated;
 use objc2::runtime::{
     AnyClass, AnyObject, Bool, ClassBuilder, NSObjectProtocol, ProtocolObject, Sel,
 };
-use objc2::{msg_send, sel, AllocAnyThread, ClassType};
+use objc2::{msg_send, sel, AllocAnyThread, ClassType, Message, ProtocolType};
 use objc2_app_kit::{
-    NSDragOperation, NSDraggingInfo, NSEvent, NSFilenamesPboardType, NSTrackingArea,
-    NSTrackingAreaOptions, NSView, NSWindow, NSWindowDidBecomeKeyNotification,
-    NSWindowDidResignKeyNotification,
+    NSDragOperation, NSDraggingContext, NSDraggingInfo, NSDraggingSession, NSDraggingSource,
+    NSEvent, NSFilenamesPboardType, NSTrackingArea, NSTrackingAreaOptions, NSView, NSWindow,
+    NSWindowDidBecomeKeyNotification, NSWindowDidResignKeyNotification,
 };
 use objc2_core_foundation::CFUUID;
 use objc2_foundation::{
@@ -226,12 +226,19 @@ unsafe fn create_view_class() -> &'static AnyClass {
             sel!(draggingExited:),
             dragging_exited as extern "C-unwind" fn(_, _, _) -> _,
         );
+        if let Some(protocol) = <dyn NSDraggingSource as ProtocolType>::protocol() {
+            class.add_protocol(protocol);
+        }
+        class.add_method(
+            sel!(draggingSession:sourceOperationMaskForDraggingContext:),
+            source_operation_mask_for_dragging_context as extern "C-unwind" fn(_, _, _, _) -> _,
+        );
         class.add_method(
             sel!(handleNotification:),
             handle_notification as extern "C-unwind" fn(_, _, _) -> _,
         );
 
-        add_mouse_button_class_method!(class, mouseDown, ButtonPressed, MouseButton::Left);
+        class.add_method(sel!(mouseDown:), mouse_down as extern "C-unwind" fn(_, _, _) -> _);
         add_mouse_button_class_method!(class, mouseUp, ButtonReleased, MouseButton::Left);
         add_mouse_button_class_method!(class, rightMouseDown, ButtonPressed, MouseButton::Right);
         add_mouse_button_class_method!(class, rightMouseUp, ButtonReleased, MouseButton::Right);
@@ -509,6 +516,25 @@ fn on_event(window_state: &WindowState, event: MouseEvent) -> NSDragOperation {
         EventStatus::AcceptDrop(DropEffect::Move) => NSDragOperation::Move,
         EventStatus::AcceptDrop(DropEffect::Link) => NSDragOperation::Link,
         EventStatus::AcceptDrop(DropEffect::Scroll) => NSDragOperation::Generic,
+        _ => NSDragOperation::None,
+    }
+}
+
+extern "C-unwind" fn mouse_down(this: &NSView, _: Sel, event: &NSEvent) {
+    let state = unsafe { WindowState::from_view(this) };
+    state.window_inner.last_mouse_down.replace(Some(event.retain()));
+    state.trigger_event(Event::Mouse(ButtonPressed {
+        button: MouseButton::Left,
+        modifiers: make_modifiers(event.modifierFlags()),
+    }));
+}
+
+extern "C-unwind" fn source_operation_mask_for_dragging_context(
+    _this: &NSView, _: Sel, _session: &NSDraggingSession, context: NSDraggingContext,
+) -> NSDragOperation {
+    match context {
+        NSDraggingContext::WithinApplication => NSDragOperation::Generic,
+        NSDraggingContext::OutsideApplication => NSDragOperation::Copy,
         _ => NSDragOperation::None,
     }
 }

--- a/src/macos/window.rs
+++ b/src/macos/window.rs
@@ -6,23 +6,24 @@ use std::rc::Rc;
 
 use keyboard_types::KeyboardEvent;
 use objc2::rc::{autoreleasepool, Retained};
-use objc2::runtime::NSObjectProtocol;
-use objc2::{msg_send, MainThreadMarker, MainThreadOnly};
+use objc2::runtime::{NSObjectProtocol, ProtocolObject};
+use objc2::{msg_send, AnyThread, MainThreadMarker, MainThreadOnly};
 use objc2_app_kit::{
-    NSApplication, NSApplicationActivationPolicy, NSBackingStoreType, NSEvent, NSPasteboard,
-    NSPasteboardTypeString, NSView, NSWindow, NSWindowStyleMask,
+    NSApplication, NSApplicationActivationPolicy, NSBackingStoreType, NSColor, NSDraggingItem,
+    NSDraggingSession, NSEvent, NSImage, NSPasteboard, NSPasteboardTypeString, NSView, NSWindow,
+    NSWindowStyleMask,
 };
 use objc2_core_foundation::{
     kCFAllocatorDefault, kCFRunLoopDefaultMode, CFRunLoop, CFRunLoopTimer, CFRunLoopTimerContext,
 };
-use objc2_foundation::{NSNotificationCenter, NSPoint, NSRect, NSSize, NSString};
+use objc2_foundation::{NSArray, NSNotificationCenter, NSPoint, NSRect, NSSize, NSString, NSURL};
 use raw_window_handle::{
     AppKitDisplayHandle, AppKitWindowHandle, HasRawDisplayHandle, HasRawWindowHandle,
     RawDisplayHandle, RawWindowHandle,
 };
 
 use crate::{
-    Event, EventStatus, MouseCursor, Size, WindowHandler, WindowInfo, WindowOpenOptions,
+    DropData, Event, EventStatus, MouseCursor, Size, WindowHandler, WindowInfo, WindowOpenOptions,
     WindowScalePolicy,
 };
 
@@ -68,6 +69,9 @@ pub(super) struct WindowInner {
 
     /// Our subclassed NSView
     ns_view: RetainedCell<NSView>,
+
+    /// Required for drag support
+    pub(super) last_mouse_down: RefCell<Option<Retained<NSEvent>>>,
 
     #[cfg(feature = "opengl")]
     pub(super) gl_context: Option<GlContext>,
@@ -179,6 +183,7 @@ impl<'a> Window<'a> {
                 ns_window: RetainedCell::empty(),
                 parent_ns_window: RetainedCell::with(parent_window.clone()),
                 ns_view: RetainedCell::new(ns_view.clone()),
+                last_mouse_down: RefCell::new(None),
 
                 #[cfg(feature = "opengl")]
                 gl_context: options
@@ -253,6 +258,7 @@ impl<'a> Window<'a> {
                 ns_app: RetainedCell::new(app.clone()),
                 parent_ns_window: RetainedCell::empty(),
                 ns_view: RetainedCell::new(ns_view.clone()),
+                last_mouse_down: RefCell::new(None),
 
                 #[cfg(feature = "opengl")]
                 gl_context: options.gl_config.map(|gl_config| {
@@ -362,6 +368,76 @@ impl<'a> Window<'a> {
                 ns_window.setContentSize(size);
             }
         }
+    }
+
+    #[allow(deprecated)]
+    fn drag_image(size: NSSize) -> Retained<NSImage> {
+        let image = NSImage::initWithSize(NSImage::alloc(), size);
+        let color = NSColor::colorWithRed_green_blue_alpha(0.3, 0.3, 0.3, 0.5);
+        image.lockFocus();
+        color.drawSwatchInRect(NSRect::new(NSPoint::ZERO, size));
+        image.unlockFocus();
+        image
+    }
+
+    pub fn start_drag(&self, data: DropData) {
+        let DropData::Files(paths) = data else {
+            return;
+        };
+        if paths.is_empty() {
+            return;
+        }
+
+        let Some(_mtm) = MainThreadMarker::new() else {
+            panic!("start_drag must be called on the main thread");
+        };
+
+        let Some(ns_view) = self.inner.ns_view.get() else {
+            return;
+        };
+
+        let Some(event) = self.inner.last_mouse_down.borrow().clone() else {
+            panic!("Expected a mouse down event before dragging");
+        };
+
+        let point = event.locationInWindow();
+        let point = ns_view.convertPoint_fromView(point, None);
+
+        let size = NSSize::new(20.0, 20.0);
+        let image = Self::drag_image(size);
+        let frame = NSRect::new(
+            NSPoint::new(point.x - (size.width / 2.0), point.y - (size.height / 2.0)),
+            size,
+        );
+
+        let mut file_urls = Vec::with_capacity(paths.len());
+        let mut dragging_items = Vec::with_capacity(paths.len());
+
+        for (i, path) in paths.into_iter().enumerate() {
+            let path_string = NSString::from_str(&path.into_os_string().into_string().unwrap());
+            let file_url = NSURL::fileURLWithPath(&path_string);
+            let writer = ProtocolObject::from_ref(&*file_url);
+            let dragging_item =
+                NSDraggingItem::initWithPasteboardWriter(NSDraggingItem::alloc(), writer);
+            unsafe {
+                dragging_item
+                    .setDraggingFrame_contents(frame, if i == 0 { Some(&*image) } else { None });
+            }
+            file_urls.push(file_url);
+            dragging_items.push(dragging_item);
+        }
+
+        let items = NSArray::from_retained_slice(&dragging_items);
+        // Our custom NSView subclass implements NSDraggingSource at runtime, but Rust
+        // doesn't know that statically, so use msg_send! for the source argument.
+        let _session: Retained<NSDraggingSession> = unsafe {
+            msg_send![
+                &*ns_view,
+                beginDraggingSessionWithItems: &*items,
+                event: &*event,
+                source: &*ns_view,
+            ]
+        };
     }
 
     pub fn set_mouse_cursor(&mut self, _mouse_cursor: MouseCursor) {

--- a/src/win/drag.rs
+++ b/src/win/drag.rs
@@ -1,0 +1,61 @@
+// https://github.com/superlistapp/super_native_extensions/blob/beabd4aca7f353a94f41b635aace9e625ca89aff/super_native_extensions/rust/src/win32/drag.rs
+// used as a reference
+
+use windows::core::implement;
+use windows::Win32::Foundation::{
+    DRAGDROP_S_CANCEL, DRAGDROP_S_DROP, DRAGDROP_S_USEDEFAULTCURSORS, S_OK,
+};
+use windows::Win32::System::Ole::{
+    DoDragDrop, IDropSource, IDropSource_Impl, DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_NONE,
+};
+use windows::Win32::System::SystemServices::{MK_LBUTTON, MODIFIERKEYS_FLAGS};
+use windows_core::BOOL;
+
+use super::drag_source::DragSourceDataObject;
+use crate::DropData;
+
+pub fn start_drag(data: DropData) {
+    if !matches!(data, DropData::Files(ref paths) if !paths.is_empty()) {
+        return;
+    }
+
+    let data_object = DragSourceDataObject::create(data);
+    let drop_source = DropSource::create();
+    let mut effects_out = DROPEFFECT_NONE;
+    unsafe {
+        let _ = DoDragDrop(
+            &data_object,
+            &drop_source,
+            DROPEFFECT_COPY,
+            &mut effects_out as *mut DROPEFFECT,
+        );
+    }
+}
+
+#[implement(IDropSource)]
+pub struct DropSource {}
+
+impl DropSource {
+    pub fn create() -> IDropSource {
+        Self {}.into()
+    }
+}
+
+#[allow(non_snake_case)]
+impl IDropSource_Impl for DropSource_Impl {
+    fn QueryContinueDrag(
+        &self, fescapepressed: BOOL, grfkeystate: MODIFIERKEYS_FLAGS,
+    ) -> windows_core::HRESULT {
+        if fescapepressed.as_bool() {
+            DRAGDROP_S_CANCEL
+        } else if grfkeystate.0 & MK_LBUTTON.0 == 0 {
+            DRAGDROP_S_DROP
+        } else {
+            S_OK
+        }
+    }
+
+    fn GiveFeedback(&self, _dweffect: DROPEFFECT) -> windows_core::HRESULT {
+        DRAGDROP_S_USEDEFAULTCURSORS
+    }
+}

--- a/src/win/drag_source.rs
+++ b/src/win/drag_source.rs
@@ -1,0 +1,192 @@
+// https://github.com/superlistapp/super_native_extensions/blob/beabd4aca7f353a94f41b635aace9e625ca89aff/super_native_extensions/rust/src/win32/drag.rs
+// used as a reference
+
+use windows::core::implement;
+use windows::Win32::Foundation::{
+    GlobalFree, DATA_S_SAMEFORMATETC, DV_E_FORMATETC, E_NOTIMPL, E_OUTOFMEMORY, HGLOBAL,
+    OLE_E_ADVISENOTSUPPORTED, POINT, S_FALSE, S_OK,
+};
+use windows::Win32::System::Com::{
+    IAdviseSink, IDataObject, IDataObject_Impl, IEnumFORMATETC, IEnumSTATDATA, DATADIR_GET,
+    FORMATETC, STGMEDIUM, STGMEDIUM_0, STREAM_SEEK_END, TYMED_HGLOBAL, TYMED_ISTREAM,
+};
+use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GLOBAL_ALLOC_FLAGS};
+use windows::Win32::System::Ole::CF_HDROP;
+use windows::Win32::UI::Shell::{SHCreateMemStream, SHCreateStdEnumFmtEtc, DROPFILES, HDROP};
+use windows_core::{Ref, BOOL};
+
+use crate::DropData;
+
+#[derive(Debug, Clone)]
+#[implement(IDataObject)]
+pub struct DragSourceDataObject {
+    data: DropData,
+}
+
+impl DragSourceDataObject {
+    pub fn create(data: DropData) -> IDataObject {
+        Self { data }.into()
+    }
+
+    fn global_from_data(data: &[u8]) -> windows::core::Result<HGLOBAL> {
+        unsafe {
+            let global =
+                GlobalAlloc(GLOBAL_ALLOC_FLAGS(0), data.len() + std::mem::size_of::<HDROP>())?;
+            let hdrop_ptr = GlobalLock(global);
+            if hdrop_ptr.is_null() {
+                GlobalFree(Some(global))?;
+                Err(E_OUTOFMEMORY.into())
+            } else {
+                std::ptr::copy_nonoverlapping(data.as_ptr(), hdrop_ptr as *mut u8, data.len());
+                let _ = GlobalUnlock(global);
+                Ok(global)
+            }
+        }
+    }
+
+    fn data_for_hdrop(paths: &[std::path::PathBuf]) -> Vec<u8> {
+        let mut res = Vec::new();
+
+        let drop_files = DROPFILES {
+            pFiles: std::mem::size_of::<DROPFILES>() as u32,
+            pt: POINT { x: 0, y: 0 },
+            fNC: false.into(),
+            fWide: true.into(),
+        };
+
+        let drop_files = unsafe {
+            std::slice::from_raw_parts(
+                (&drop_files as *const DROPFILES) as *const u8,
+                std::mem::size_of::<DROPFILES>(),
+            )
+        };
+        res.extend_from_slice(drop_files);
+
+        for path in paths {
+            let mut file_str: Vec<u16> =
+                path.clone().into_os_string().into_string().unwrap().encode_utf16().collect();
+            // https://learn.microsoft.com/en-us/windows/win32/shell/clipboard#cf_hdrop
+            file_str.push(0);
+
+            let data = unsafe {
+                std::slice::from_raw_parts(
+                    file_str.as_ptr() as *const u8,
+                    file_str.len() * std::mem::size_of::<u16>(),
+                )
+            };
+            res.extend_from_slice(data);
+        }
+
+        // Double null terminated
+        res.extend_from_slice(&[0, 0]);
+
+        res
+    }
+}
+
+#[allow(non_snake_case)]
+impl IDataObject_Impl for DragSourceDataObject_Impl {
+    fn GetData(&self, pformatetcin: *const FORMATETC) -> windows::core::Result<STGMEDIUM> {
+        match &self.data {
+            DropData::Files(paths) if !paths.is_empty() => {
+                let format = unsafe { &*pformatetcin };
+                let data = DragSourceDataObject::data_for_hdrop(paths);
+
+                if (format.tymed & TYMED_HGLOBAL.0 as u32) != 0 {
+                    let global = DragSourceDataObject::global_from_data(&data)?;
+                    Ok(STGMEDIUM {
+                        tymed: TYMED_HGLOBAL.0 as u32,
+                        u: STGMEDIUM_0 { hGlobal: global },
+                        pUnkForRelease: std::mem::ManuallyDrop::new(None),
+                    })
+                } else if (format.tymed & TYMED_ISTREAM.0 as u32) != 0 {
+                    let stream = unsafe { SHCreateMemStream(Some(&data)) };
+                    let stream =
+                        stream.ok_or_else(|| windows::core::Error::from(DV_E_FORMATETC))?;
+                    unsafe {
+                        stream.Seek(0, STREAM_SEEK_END, None)?;
+                    }
+                    Ok(STGMEDIUM {
+                        tymed: TYMED_ISTREAM.0 as u32,
+                        u: STGMEDIUM_0 { pstm: std::mem::ManuallyDrop::new(Some(stream)) },
+                        pUnkForRelease: std::mem::ManuallyDrop::new(None),
+                    })
+                } else {
+                    Err(DV_E_FORMATETC.into())
+                }
+            }
+            _ => Err(DV_E_FORMATETC.into()),
+        }
+    }
+
+    fn GetDataHere(
+        &self, _pformatetc: *const FORMATETC, _pmedium: *mut STGMEDIUM,
+    ) -> windows::core::Result<()> {
+        Err(E_NOTIMPL.into())
+    }
+
+    fn QueryGetData(&self, pformatetc: *const FORMATETC) -> windows::core::HRESULT {
+        let format = unsafe { &*pformatetc };
+        if (format.tymed == TYMED_HGLOBAL.0 as u32 || format.tymed == TYMED_ISTREAM.0 as u32)
+            && format.cfFormat == CF_HDROP.0
+        {
+            S_OK
+        } else {
+            S_FALSE
+        }
+    }
+
+    fn GetCanonicalFormatEtc(
+        &self, pformatectin: *const FORMATETC, pformatetcout: *mut FORMATETC,
+    ) -> windows::core::HRESULT {
+        let fmt_out = unsafe { &mut *pformatetcout };
+        let fmt_in = unsafe { &*pformatectin };
+        *fmt_out = *fmt_in;
+        DATA_S_SAMEFORMATETC
+    }
+
+    fn SetData(
+        &self, _pformatetc: *const FORMATETC, _pmedium: *const STGMEDIUM, _frelease: BOOL,
+    ) -> windows::core::Result<()> {
+        Err(E_NOTIMPL.into())
+    }
+
+    fn EnumFormatEtc(&self, dwdirection: u32) -> windows::core::Result<IEnumFORMATETC> {
+        if dwdirection == DATADIR_GET.0 as u32 {
+            unsafe {
+                SHCreateStdEnumFmtEtc(&[
+                    FORMATETC {
+                        cfFormat: CF_HDROP.0,
+                        ptd: std::ptr::null_mut(),
+                        dwAspect: 1,
+                        lindex: -1,
+                        tymed: TYMED_HGLOBAL.0 as u32,
+                    },
+                    FORMATETC {
+                        cfFormat: CF_HDROP.0,
+                        ptd: std::ptr::null_mut(),
+                        dwAspect: 1,
+                        lindex: -1,
+                        tymed: TYMED_ISTREAM.0 as u32,
+                    },
+                ])
+            }
+        } else {
+            Err(E_NOTIMPL.into())
+        }
+    }
+
+    fn DAdvise(
+        &self, _pformatetc: *const FORMATETC, _advf: u32, _padvsink: Ref<IAdviseSink>,
+    ) -> windows::core::Result<u32> {
+        Err(OLE_E_ADVISENOTSUPPORTED.into())
+    }
+
+    fn DUnadvise(&self, _dwconnection: u32) -> windows::core::Result<()> {
+        Err(OLE_E_ADVISENOTSUPPORTED.into())
+    }
+
+    fn EnumDAdvise(&self) -> windows::core::Result<IEnumSTATDATA> {
+        Err(OLE_E_ADVISENOTSUPPORTED.into())
+    }
+}

--- a/src/win/mod.rs
+++ b/src/win/mod.rs
@@ -1,4 +1,6 @@
 mod cursor;
+mod drag;
+mod drag_source;
 mod drop_target;
 mod hook;
 mod keyboard;

--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -45,8 +45,8 @@ const BV_WINDOW_MUST_CLOSE: u32 = WM_USER + 1;
 
 use crate::win::hook::{self, KeyboardHookHandle};
 use crate::{
-    Event, MouseButton, MouseCursor, MouseEvent, PhyPoint, PhySize, ScrollDelta, Size, WindowEvent,
-    WindowHandler, WindowInfo, WindowOpenOptions, WindowScalePolicy,
+    DropData, Event, MouseButton, MouseCursor, MouseEvent, PhyPoint, PhySize, ScrollDelta, Size,
+    WindowEvent, WindowHandler, WindowInfo, WindowOpenOptions, WindowScalePolicy,
 };
 
 use super::cursor::cursor_to_lpcwstr;
@@ -562,6 +562,9 @@ impl WindowState {
                     )
                 };
             }
+            WindowTask::Drag(data) => {
+                super::drag::start_drag(data);
+            }
         }
     }
 }
@@ -573,6 +576,8 @@ pub(super) enum WindowTask {
     /// Resize the window to the given size. The size is in logical pixels. DPI scaling is applied
     /// automatically.
     Resize(Size),
+    /// Start a drag operation with the given data.
+    Drag(DropData),
 }
 
 pub struct Window<'a> {
@@ -813,6 +818,13 @@ impl Window<'_> {
         // To avoid reentrant event handler calls we'll defer the actual resizing until after the
         // event has been handled
         let task = WindowTask::Resize(size);
+        self.state.deferred_tasks.borrow_mut().push_back(task);
+    }
+
+    pub fn start_drag(&self, data: DropData) {
+        // To avoid reentrant event handler calls we'll defer the actual drag until after the
+        // event has been handled
+        let task = WindowTask::Drag(data);
         self.state.deferred_tasks.borrow_mut().push_back(task);
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,7 +4,7 @@ use raw_window_handle::{
     HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
 
-use crate::event::{Event, EventStatus};
+use crate::event::{DropData, Event, EventStatus};
 use crate::window_open_options::WindowOpenOptions;
 use crate::{MouseCursor, Size};
 
@@ -96,6 +96,11 @@ impl<'a> Window<'a> {
     /// automatically be accounted for.
     pub fn resize(&mut self, size: Size) {
         self.window.resize(size);
+    }
+
+    /// Initiate a drag operation with the given data.
+    pub fn start_drag(&self, data: DropData) {
+        self.window.start_drag(data);
     }
 
     pub fn set_mouse_cursor(&mut self, cursor: MouseCursor) {

--- a/src/x11/window.rs
+++ b/src/x11/window.rs
@@ -21,7 +21,7 @@ use x11rb::wrapper::ConnectionExt as _;
 
 use super::XcbConnection;
 use crate::{
-    Event, MouseCursor, Size, WindowEvent, WindowHandler, WindowInfo, WindowOpenOptions,
+    DropData, Event, MouseCursor, Size, WindowEvent, WindowHandler, WindowInfo, WindowOpenOptions,
     WindowScalePolicy,
 };
 
@@ -342,6 +342,10 @@ impl<'a> Window<'a> {
 
         // This will trigger a `ConfigureNotify` event which will in turn change `self.window_info`
         // and notify the window handler about it
+    }
+
+    pub fn start_drag(&self, _data: DropData) {
+        todo!("Drag initiation is not yet supported on Linux")
     }
 
     #[cfg(feature = "opengl")]


### PR DESCRIPTION
This lets a baseview window become the *source* of a drag event. Why is this useful? Say you want to create a plugin that can generate MIDI. Acting as a drag source lets you drag some MIDI sequence straight into your DAW (e.g. see the screencap here: https://github.com/AlexCharlton/midi-m8/)