### PR TITLE
Make the Windows handler reentrancy-safe (fix "already borrowed" panic on resize)

### DIFF
--- a/src/win/window.rs
+++ b/src/win/window.rs
@@ -528,16 +528,25 @@ impl WindowState {
     }
 
     pub(crate) fn handle_on_frame(&self) {
-        let mut handler = self.handler.borrow_mut();
+        // Use `try_borrow_mut` so a re-entrant call (e.g. a synchronous `WM_SIZE`
+        // dispatched by a `SetWindowPos`/host resize that happens *inside* the
+        // handler) is skipped instead of panicking with "already borrowed".
+        let Ok(mut handler) = self.handler.try_borrow_mut() else {
+            return;
+        };
         let Some(handler) = handler.as_mut() else { return };
         let mut window = crate::window::Window::new(Window { state: self });
 
         handler.on_frame(&mut window)
     }
 
-    pub(crate) fn handle_event(&self, event: Event) -> EventStatus {
-        let mut handler = self.handler.borrow_mut();
-
+     pub(crate) fn handle_event(&self, event: Event) -> EventStatus {
+        // See `handle_on_frame`: skip re-entrant events rather than panicking on
+        // a double `borrow_mut`. This is what makes resizing from within a
+        // handler callback safe (the host's resize synchronously re-enters here).
+        let Ok(mut handler) = self.handler.try_borrow_mut() else {
+            return EventStatus::Ignored;
+        };
         let Some(handler) = handler.as_mut() else {
             return EventStatus::Ignored;
         };


### PR DESCRIPTION
### Problem

On Windows, `WindowState::handle_on_frame` and `handle_event` hold
`self.handler.borrow_mut()` for the full duration of the user's `on_frame` /
`on_event` callback. If the callback causes Windows to synchronously dispatch
another message into the window procedure, the wndproc re-enters `handle_event`,
calls `borrow_mut()` again, and panics with `already borrowed: BorrowMutError`.

The most common trigger is resizing: calling a host's resize request (or a
`SetWindowPos`) from inside a handler callback synchronously sends `WM_SIZE` back
into the window proc. In an audio-plugin host this panic unwinds across the FFI
boundary and crashes the DAW.

This is reproducible whenever a baseview-hosted GUI tries to resize its own
window in response to user interaction (e.g. a draggable resize affordance that
asks the host to grow the editor).

### Fix

Use `try_borrow_mut()` in both `handle_on_frame` and `handle_event` and skip the
event if the handler is already borrowed, instead of panicking. The handler is
not reentrant, so dropping the nested call is the correct behavior — the window
state remains consistent and the next genuine frame/event observes the latest
size.

This brings the Windows backend in line with how non-reentrant event loops are
expected to behave and makes it safe to invoke host resize APIs from within a
handler callback.

### Scope

- Windows only (`src/win/window.rs`), two call sites.
- No public API change; no behavior change except that a previously-fatal
  re-entrant callback is now skipped instead of panicking.