### PR TITLE
Embrace reentrancy

### DIFF
--- a/examples/open_parented/src/main.rs
+++ b/examples/open_parented/src/main.rs
@@ -2,13 +2,14 @@ use baseview::{
     Event, EventStatus, PhySize, Window, WindowEvent, WindowHandle, WindowHandler,
     WindowOpenOptions,
 };
+use std::cell::{Cell, RefCell};
 use std::num::NonZeroU32;
 
 struct ParentWindowHandler {
     _ctx: softbuffer::Context,
-    surface: softbuffer::Surface,
-    current_size: PhySize,
-    damaged: bool,
+    surface: RefCell<softbuffer::Surface>,
+    current_size: Cell<PhySize>,
+    damaged: Cell<bool>,
 
     _child_window: Option<WindowHandle>,
 }
@@ -28,36 +29,37 @@ impl ParentWindowHandler {
         // TODO: no way to query physical size initially?
         Self {
             _ctx: ctx,
-            surface,
-            current_size: PhySize::new(512, 512),
-            damaged: true,
+            surface: surface.into(),
+            current_size: PhySize::new(512, 512).into(),
+            damaged: true.into(),
             _child_window: Some(child_window),
         }
     }
 }
 
 impl WindowHandler for ParentWindowHandler {
-    fn on_frame(&mut self, _window: &mut Window) {
-        let mut buf = self.surface.buffer_mut().unwrap();
-        if self.damaged {
+    fn on_frame(&self, _window: &mut Window) {
+        let mut surface = self.surface.borrow_mut();
+        let mut buf = surface.buffer_mut().unwrap();
+        if self.damaged.get() {
             buf.fill(0xFFAAAAAA);
-            self.damaged = false;
+            self.damaged.set(false);
         }
         buf.present().unwrap();
     }
 
-    fn on_event(&mut self, _window: &mut Window, event: Event) -> EventStatus {
+    fn on_event(&self, _window: &mut Window, event: Event) -> EventStatus {
         match event {
             Event::Window(WindowEvent::Resized(info)) => {
                 println!("Parent Resized: {:?}", info);
                 let new_size = info.physical_size();
-                self.current_size = new_size;
+                self.current_size.set(new_size);
 
                 if let (Some(width), Some(height)) =
                     (NonZeroU32::new(new_size.width), NonZeroU32::new(new_size.height))
                 {
-                    self.surface.resize(width, height).unwrap();
-                    self.damaged = true;
+                    self.surface.borrow_mut().resize(width, height).unwrap();
+                    self.damaged.set(true);
                 }
             }
             Event::Mouse(e) => println!("Parent Mouse event: {:?}", e),
@@ -71,9 +73,9 @@ impl WindowHandler for ParentWindowHandler {
 
 struct ChildWindowHandler {
     _ctx: softbuffer::Context,
-    surface: softbuffer::Surface,
-    current_size: PhySize,
-    damaged: bool,
+    surface: RefCell<softbuffer::Surface>,
+    current_size: Cell<PhySize>,
+    damaged: Cell<bool>,
 }
 
 impl ChildWindowHandler {
@@ -83,32 +85,38 @@ impl ChildWindowHandler {
         surface.resize(NonZeroU32::new(512).unwrap(), NonZeroU32::new(512).unwrap()).unwrap();
 
         // TODO: no way to query physical size initially?
-        Self { _ctx: ctx, surface, current_size: PhySize::new(256, 256), damaged: true }
+        Self {
+            _ctx: ctx,
+            surface: surface.into(),
+            current_size: PhySize::new(256, 256).into(),
+            damaged: true.into(),
+        }
     }
 }
 
 impl WindowHandler for ChildWindowHandler {
-    fn on_frame(&mut self, _window: &mut Window) {
-        let mut buf = self.surface.buffer_mut().unwrap();
-        if self.damaged {
+    fn on_frame(&self, _window: &mut Window) {
+        let mut surface = self.surface.borrow_mut();
+        let mut buf = surface.buffer_mut().unwrap();
+        if self.damaged.get() {
             buf.fill(0xFFAA0000);
-            self.damaged = false;
+            self.damaged.set(false);
         }
         buf.present().unwrap();
     }
 
-    fn on_event(&mut self, _window: &mut Window, event: Event) -> EventStatus {
+    fn on_event(&self, _window: &mut Window, event: Event) -> EventStatus {
         match event {
             Event::Window(WindowEvent::Resized(info)) => {
                 println!("Child Resized: {:?}", info);
                 let new_size = info.physical_size();
-                self.current_size = new_size;
+                self.current_size.set(new_size);
 
                 if let (Some(width), Some(height)) =
                     (NonZeroU32::new(new_size.width), NonZeroU32::new(new_size.height))
                 {
-                    self.surface.resize(width, height).unwrap();
-                    self.damaged = true;
+                    self.surface.borrow_mut().resize(width, height).unwrap();
+                    self.damaged.set(true);
                 }
             }
             Event::Mouse(e) => println!("Child Mouse event: {:?}", e),

--- a/examples/open_window/src/main.rs
+++ b/examples/open_window/src/main.rs
@@ -1,3 +1,4 @@
+use std::cell::{Cell, RefCell};
 use std::num::NonZeroU32;
 use std::time::Duration;
 
@@ -16,14 +17,14 @@ enum Message {
 }
 
 struct OpenWindowExample {
-    rx: Consumer<Message>,
+    rx: RefCell<Consumer<Message>>,
 
     _ctx: softbuffer::Context,
-    surface: softbuffer::Surface,
-    current_size: WindowInfo,
-    mouse_pos: PhyPoint,
-    is_cursor_inside: bool,
-    damaged: bool,
+    surface: RefCell<softbuffer::Surface>,
+    current_size: Cell<WindowInfo>,
+    mouse_pos: Cell<PhyPoint>,
+    is_cursor_inside: Cell<bool>,
+    damaged: Cell<bool>,
 }
 
 impl WindowHandler for OpenWindowExample {
@@ -32,9 +33,10 @@ impl WindowHandler for OpenWindowExample {
             return;
         }
 
-        let mut pixels = self.surface.buffer_mut().unwrap();
-        let size = self.current_size.physical_size();
-        let scale_factor = self.current_size.scale();
+        let mut surface = self.surface.borrow_mut();
+        let mut pixels = surface.buffer_mut().unwrap();
+        let size = self.current_size.get().physical_size();
+        let scale_factor = self.current_size.get().scale();
         let (width, height) = (size.width, size.height);
 
         for index in 0..(width * height) {
@@ -75,10 +77,10 @@ impl WindowHandler for OpenWindowExample {
         if self.is_cursor_inside {
             let rect_size = (25.0 * scale_factor) as i32;
 
-            let rect_x_start = (self.mouse_pos.x - rect_size).clamp(0, width as i32) as u32;
-            let rect_x_end = (self.mouse_pos.x + rect_size).clamp(0, width as i32) as u32;
-            let rect_y_start = (self.mouse_pos.y - rect_size).clamp(0, height as i32) as u32;
-            let rect_y_end = (self.mouse_pos.y + rect_size).clamp(0, height as i32) as u32;
+            let rect_x_start = (self.mouse_pos.get().x - rect_size).clamp(0, width as i32) as u32;
+            let rect_x_end = (self.mouse_pos.get().x + rect_size).clamp(0, width as i32) as u32;
+            let rect_y_start = (self.mouse_pos.get().y - rect_size).clamp(0, height as i32) as u32;
+            let rect_y_end = (self.mouse_pos.get().y + rect_size).clamp(0, height as i32) as u32;
 
             for x in rect_x_start..rect_x_end {
                 for y in rect_y_start..rect_y_end {
@@ -89,41 +91,41 @@ impl WindowHandler for OpenWindowExample {
         }
 
         pixels.present().unwrap();
-        self.damaged = false;
+        self.damaged.set(false);
 
-        while let Ok(message) = self.rx.pop() {
+        while let Ok(message) = self.rx.borrow_mut().pop() {
             println!("Message: {:?}", message);
         }
     }
 
-    fn on_event(&mut self, _window: &mut Window, event: Event) -> EventStatus {
+    fn on_event(&self, _window: &mut Window, event: Event) -> EventStatus {
         match &event {
             #[cfg(target_os = "macos")]
             Event::Mouse(MouseEvent::ButtonPressed { .. }) => copy_to_clipboard("This is a test!"),
             Event::Mouse(MouseEvent::CursorMoved { position, .. }) => {
-                let phy_pos = position.to_physical(&self.current_size);
-                self.mouse_pos = phy_pos;
-                self.damaged = true;
+                let phy_pos = position.to_physical(&self.current_size.get());
+                self.mouse_pos.set(phy_pos);
+                self.damaged.set(true);
             }
             Event::Mouse(MouseEvent::CursorEntered) => {
-                self.is_cursor_inside = true;
-                self.damaged = true;
+                self.is_cursor_inside.set(true);
+                self.damaged.set(true);
             }
             Event::Mouse(MouseEvent::CursorLeft) => {
-                self.is_cursor_inside = false;
-                self.damaged = true;
+                self.is_cursor_inside.set(false);
+                self.damaged.set(true);
             }
             Event::Window(WindowEvent::Resized(info)) => {
                 println!("Resized: {:?}", info);
-                self.current_size = *info;
+                self.current_size.set(*info);
 
                 let new_size = info.physical_size();
 
                 if let (Some(width), Some(height)) =
                     (NonZeroU32::new(new_size.width), NonZeroU32::new(new_size.height))
                 {
-                    self.surface.resize(width, height).unwrap();
-                    self.damaged = true;
+                    self.surface.borrow_mut().resize(width, height).unwrap();
+                    self.damaged.set(true);
                 }
             }
             _ => {}
@@ -155,12 +157,12 @@ fn main() {
 
         OpenWindowExample {
             _ctx: ctx,
-            surface,
-            rx,
-            current_size: WindowInfo::from_physical_size(PhySize::new(512, 512), 1.0),
-            mouse_pos: PhyPoint::new(0, 0),
-            is_cursor_inside: false,
-            damaged: true,
+            surface: surface.into(),
+            rx: rx.into(),
+            current_size: WindowInfo::from_physical_size(PhySize::new(512, 512).into(), 1.0).into(),
+            mouse_pos: PhyPoint::new(0, 0).into(),
+            is_cursor_inside: false.into(),
+            damaged: true.into(),
         }
     });
 }

--- a/examples/open_window/src/main.rs
+++ b/examples/open_window/src/main.rs
@@ -28,8 +28,8 @@ struct OpenWindowExample {
 }
 
 impl WindowHandler for OpenWindowExample {
-    fn on_frame(&mut self, _window: &mut Window) {
-        if !self.damaged {
+    fn on_frame(&self, _window: &mut Window) {
+        if !self.damaged.get() {
             return;
         }
 
@@ -74,7 +74,7 @@ impl WindowHandler for OpenWindowExample {
             pixels[index as usize] = if (y % 10) < 5 { 0xFFFF00FF } else { 0xFF000000 };
         }
 
-        if self.is_cursor_inside {
+        if self.is_cursor_inside.get() {
             let rect_size = (25.0 * scale_factor) as i32;
 
             let rect_x_start = (self.mouse_pos.get().x - rect_size).clamp(0, width as i32) as u32;

--- a/examples/open_window/src/main.rs
+++ b/examples/open_window/src/main.rs
@@ -159,7 +159,7 @@ fn main() {
             _ctx: ctx,
             surface: surface.into(),
             rx: rx.into(),
-            current_size: WindowInfo::from_physical_size(PhySize::new(512, 512).into(), 1.0).into(),
+            current_size: WindowInfo::from_physical_size(PhySize::new(512, 512), 1.0).into(),
             mouse_pos: PhyPoint::new(0, 0).into(),
             is_cursor_inside: false.into(),
             damaged: true.into(),

--- a/examples/render_femtovg/src/main.rs
+++ b/examples/render_femtovg/src/main.rs
@@ -5,12 +5,13 @@ use baseview::{
 };
 use femtovg::renderer::OpenGl;
 use femtovg::{Canvas, Color};
+use std::cell::{Cell, RefCell};
 
 struct FemtovgExample {
-    canvas: Canvas<OpenGl>,
-    current_size: WindowInfo,
-    current_mouse_position: PhyPoint,
-    damaged: bool,
+    canvas: RefCell<Canvas<OpenGl>>,
+    current_size: Cell<WindowInfo>,
+    current_mouse_position: Cell<PhyPoint>,
+    damaged: Cell<bool>,
 }
 
 impl FemtovgExample {
@@ -27,31 +28,34 @@ impl FemtovgExample {
 
         unsafe { context.make_not_current() };
         Self {
-            canvas,
-            current_size: WindowInfo::from_logical_size(Size { width: 512.0, height: 512.0 }, 1.0),
-            current_mouse_position: PhyPoint { x: 256, y: 256 },
-            damaged: true,
+            canvas: canvas.into(),
+            current_size: WindowInfo::from_logical_size(Size { width: 512.0, height: 512.0 }, 1.0)
+                .into(),
+            current_mouse_position: PhyPoint { x: 256, y: 256 }.into(),
+            damaged: true.into(),
         }
     }
 }
 
 impl WindowHandler for FemtovgExample {
-    fn on_frame(&mut self, window: &mut Window) {
-        if !self.damaged {
+    fn on_frame(&self, window: &mut Window) {
+        if !self.damaged.get() {
             return;
         }
 
         let context = window.gl_context().unwrap();
         unsafe { context.make_current() };
 
-        let screen_height = self.canvas.height();
-        let screen_width = self.canvas.width();
+        let mut canvas = self.canvas.borrow_mut();
+
+        let screen_height = canvas.height();
+        let screen_width = canvas.width();
 
         // Clear
-        self.canvas.clear_rect(0, 0, screen_width, screen_height, Color::rgb(0xAA, 0xAA, 0xAA));
+        canvas.clear_rect(0, 0, screen_width, screen_height, Color::rgb(0xAA, 0xAA, 0xAA));
 
         // Make big blue rectangle
-        self.canvas.clear_rect(
+        canvas.clear_rect(
             (screen_width as f32 * 0.1).floor() as u32,
             (screen_height as f32 * 0.1).floor() as u32,
             (screen_width as f32 * 0.8).floor() as u32,
@@ -60,28 +64,32 @@ impl WindowHandler for FemtovgExample {
         );
 
         // Make smol orange rectangle
-        self.canvas.clear_rect(
-            (self.current_mouse_position.x - 15).clamp(0, screen_width as i32 - 30) as u32,
-            (self.current_mouse_position.y - 15).clamp(0, screen_height as i32 - 30) as u32,
+        canvas.clear_rect(
+            (self.current_mouse_position.get().x - 15).clamp(0, screen_width as i32 - 30) as u32,
+            (self.current_mouse_position.get().y - 15).clamp(0, screen_height as i32 - 30) as u32,
             30,
             30,
             Color::rgbf(0.9, 0.3, 0.),
         );
 
         // Tell renderer to execute all drawing commands
-        self.canvas.flush();
+        canvas.flush();
         context.swap_buffers();
         unsafe { context.make_not_current() };
-        self.damaged = false;
+        self.damaged.set(false);
     }
 
-    fn on_event(&mut self, _window: &mut Window, event: Event) -> EventStatus {
+    fn on_event(&self, _window: &mut Window, event: Event) -> EventStatus {
         match event {
             Event::Window(WindowEvent::Resized(size)) => {
                 let phy_size = size.physical_size();
-                self.current_size = size;
-                self.canvas.set_size(phy_size.width, phy_size.height, size.scale() as f32);
-                self.damaged = true;
+                self.current_size.set(size);
+                self.canvas.borrow_mut().set_size(
+                    phy_size.width,
+                    phy_size.height,
+                    size.scale() as f32,
+                );
+                self.damaged.set(true);
             }
             Event::Mouse(
                 MouseEvent::CursorMoved { position, .. }
@@ -89,8 +97,8 @@ impl WindowHandler for FemtovgExample {
                 | MouseEvent::DragMoved { position, .. }
                 | MouseEvent::DragDropped { position, .. },
             ) => {
-                self.current_mouse_position = position.to_physical(&self.current_size);
-                self.damaged = true;
+                self.current_mouse_position.set(position.to_physical(&self.current_size.get()));
+                self.damaged.set(true);
             }
             _ => {}
         };

--- a/src/platform/macos/view.rs
+++ b/src/platform/macos/view.rs
@@ -167,8 +167,7 @@ impl BaseviewView {
             return EventStatus::Ignored;
         };
 
-        let status = handler.on_event(&mut this.into(), event);
-        status
+        handler.on_event(&mut this.into(), event)
     }
 
     fn trigger_frame(this: ViewRef<Self>) {

--- a/src/platform/macos/view.rs
+++ b/src/platform/macos/view.rs
@@ -17,7 +17,7 @@ use objc2_app_kit::{
     NSTrackingAreaOptions, NSView, NSWindow,
 };
 use objc2_foundation::{NSArray, NSNotification, NSPoint, NSRect, NSSize, NSString};
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, OnceCell};
 use std::rc::Rc;
 
 pub enum ViewParentingType {
@@ -27,7 +27,7 @@ pub enum ViewParentingType {
 
 pub(crate) struct BaseviewView {
     pub(crate) state: Rc<WindowSharedState>,
-    window_handler: RefCell<Option<Box<dyn WindowHandler>>>,
+    window_handler: OnceCell<Box<dyn WindowHandler>>,
 
     frame_timer: Cell<Option<TimerHandle>>,
     notification_center_observer: Cell<Option<NotificationCenterObserver>>,
@@ -37,7 +37,7 @@ pub(crate) struct BaseviewView {
     parenting: ViewParentingType,
 
     #[cfg(feature = "opengl")]
-    pub(crate) gl_context: std::cell::OnceCell<crate::gl::GlContext>,
+    pub(crate) gl_context: OnceCell<crate::gl::GlContext>,
 }
 
 impl BaseviewView {
@@ -55,12 +55,12 @@ impl BaseviewView {
 
             keyboard_state: KeyboardState::new(),
             frame_timer: None.into(),
-            window_handler: None.into(),
+            window_handler: OnceCell::new(),
             notification_center_observer: None.into(),
             parenting,
 
             #[cfg(feature = "opengl")]
-            gl_context: std::cell::OnceCell::new(),
+            gl_context: OnceCell::new(),
         };
 
         let view = View::new(view_rect, inner, |view| {
@@ -85,7 +85,9 @@ impl BaseviewView {
             }
 
             // Initialize handler
-            view.window_handler.replace(Some(Box::new(builder(&mut view.into()))));
+            let Ok(()) = view.window_handler.set(Box::new(builder(&mut view.into()))) else {
+                unreachable!()
+            };
 
             // Set up anything that might trigger events to the handler
 
@@ -162,8 +164,7 @@ impl BaseviewView {
 
     /// Trigger the event immediately and return the event status.
     fn trigger_event(this: ViewRef<Self>, event: Event) -> EventStatus {
-        let handler = this.window_handler.borrow();
-        let Some(handler) = handler.as_ref() else {
+        let Some(handler) = this.window_handler.get() else {
             return EventStatus::Ignored;
         };
 
@@ -171,8 +172,7 @@ impl BaseviewView {
     }
 
     fn trigger_frame(this: ViewRef<Self>) {
-        let handler = this.window_handler.borrow();
-        let Some(handler) = handler.as_ref() else { return };
+        let Some(handler) = this.window_handler.get() else { return };
 
         handler.on_frame(&mut this.into());
     }

--- a/src/platform/macos/view.rs
+++ b/src/platform/macos/view.rs
@@ -18,7 +18,6 @@ use objc2_app_kit::{
 };
 use objc2_foundation::{NSArray, NSNotification, NSPoint, NSRect, NSSize, NSString};
 use std::cell::{Cell, RefCell};
-use std::collections::VecDeque;
 use std::rc::Rc;
 
 pub enum ViewParentingType {
@@ -29,9 +28,6 @@ pub enum ViewParentingType {
 pub(crate) struct BaseviewView {
     pub(crate) state: Rc<WindowSharedState>,
     window_handler: RefCell<Option<Box<dyn WindowHandler>>>,
-
-    /// Events that will be triggered at the end of `window_handler`'s borrow.
-    deferred_events: RefCell<VecDeque<Event>>,
 
     frame_timer: Cell<Option<TimerHandle>>,
     notification_center_observer: Cell<Option<NotificationCenterObserver>>,
@@ -57,7 +53,6 @@ impl BaseviewView {
         let inner = BaseviewView {
             state: state.clone(),
 
-            deferred_events: RefCell::default(),
             keyboard_state: KeyboardState::new(),
             frame_timer: None.into(),
             window_handler: None.into(),
@@ -114,7 +109,7 @@ impl BaseviewView {
             view.notification_center_observer.set(Some(observer));
 
             // Send an initial Resized event so users get the correct scale factor and physical size.
-            Self::trigger_deferrable_event(
+            Self::trigger_event(
                 view,
                 Event::Window(WindowEvent::Resized(Self::fetch_view_size(view.view))),
             );
@@ -166,51 +161,21 @@ impl BaseviewView {
     }
 
     /// Trigger the event immediately and return the event status.
-    /// Will panic if `window_handler` is already borrowed (see `trigger_deferrable_event`).
     fn trigger_event(this: ViewRef<Self>, event: Event) -> EventStatus {
-        let mut handler = this.window_handler.borrow_mut();
-        let Some(handler) = handler.as_mut() else {
+        let handler = this.window_handler.borrow();
+        let Some(handler) = handler.as_ref() else {
             return EventStatus::Ignored;
         };
 
         let status = handler.on_event(&mut this.into(), event);
-        Self::send_deferred_events(this, handler.as_mut());
         status
     }
 
-    /// Trigger the event immediately if `window_handler` can be borrowed mutably,
-    /// otherwise add the event to a queue that will be cleared once `window_handler`'s mutable borrow ends.
-    /// As this method might result in the event triggering asynchronously, it can't reliably return the event status.
-    fn trigger_deferrable_event(this: ViewRef<Self>, event: Event) {
-        let Ok(mut handler) = this.window_handler.try_borrow_mut() else {
-            this.deferred_events.borrow_mut().push_back(event);
-            return;
-        };
-
-        let Some(handler) = handler.as_mut() else { return };
-
-        handler.on_event(&mut this.into(), event);
-        Self::send_deferred_events(this, handler.as_mut());
-    }
-
     fn trigger_frame(this: ViewRef<Self>) {
-        let mut handler = this.window_handler.borrow_mut();
-        let Some(handler) = handler.as_mut() else { return };
+        let handler = this.window_handler.borrow();
+        let Some(handler) = handler.as_ref() else { return };
 
         handler.on_frame(&mut this.into());
-        Self::send_deferred_events(this, handler.as_mut());
-    }
-
-    fn send_deferred_events(this: ViewRef<Self>, window_handler: &mut dyn WindowHandler) {
-        let mut window = this.into();
-        loop {
-            let next_event = { this.deferred_events.borrow_mut().pop_front() };
-            if let Some(event) = next_event {
-                window_handler.on_event(&mut window, event);
-            } else {
-                break;
-            }
-        }
     }
 
     fn fetch_view_size(view: &NSView) -> WindowInfo {
@@ -240,14 +205,14 @@ impl ViewImpl for BaseviewView {
         };
 
         if window.isKeyWindow() {
-            Self::trigger_deferrable_event(this, Event::Window(WindowEvent::Focused));
+            Self::trigger_event(this, Event::Window(WindowEvent::Focused));
         }
 
         true
     }
 
     fn resign_first_responder(this: ViewRef<Self>) -> bool {
-        Self::trigger_deferrable_event(this, Event::Window(WindowEvent::Unfocused));
+        Self::trigger_event(this, Event::Window(WindowEvent::Unfocused));
         true
     }
 
@@ -266,10 +231,7 @@ impl ViewImpl for BaseviewView {
         // other platform implementations
         if new_window_info.physical_size() != window_info.physical_size() {
             this.state.window_info.set(new_window_info);
-            Self::trigger_deferrable_event(
-                this,
-                Event::Window(WindowEvent::Resized(new_window_info)),
-            );
+            Self::trigger_event(this, Event::Window(WindowEvent::Resized(new_window_info)));
         }
     }
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -1,4 +1,4 @@
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use objc2::rc::{autoreleasepool, Weak};
@@ -22,12 +22,12 @@ use crate::platform::macos::view::{BaseviewView, ViewParentingType};
 use crate::wrappers::appkit::{create_window, extract_raw_window_handle, View, ViewRef};
 
 pub struct WindowHandle {
-    view: Option<Weak<View<BaseviewView>>>,
+    view: RefCell<Option<Weak<View<BaseviewView>>>>,
     state: Rc<WindowSharedState>,
 }
 
 impl WindowHandle {
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         let Some(view) = self.view.take().and_then(|w| w.load()) else {
             return;
         };
@@ -42,7 +42,7 @@ impl WindowHandle {
 
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        let Some(view) = self.view.as_ref().and_then(|w| w.load()) else {
+        let Some(view) = self.view.borrow().as_ref().and_then(|w| w.load()) else {
             return AppKitWindowHandle::empty().into();
         };
 
@@ -82,7 +82,7 @@ impl<'a> Window<'a> {
 
             let (ns_view, state) = BaseviewView::new(options, build, parenting);
 
-            WindowHandle { view: Some(Weak::from_retained(&ns_view)), state }
+            WindowHandle { view: Some(Weak::from_retained(&ns_view)).into(), state }
         })
     }
 
@@ -120,11 +120,11 @@ impl<'a> Window<'a> {
         })
     }
 
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         BaseviewView::close(self.view.inner_ref());
     }
 
-    pub fn has_focus(&mut self) -> bool {
+    pub fn has_focus(&self) -> bool {
         let Some(window) = self.view.window() else {
             return false;
         };
@@ -140,13 +140,13 @@ impl<'a> Window<'a> {
         self.view.isEqual(Some(&*first_responder))
     }
 
-    pub fn focus(&mut self) {
+    pub fn focus(&self) {
         if let Some(window) = self.view.window() {
             window.makeFirstResponder(Some(self.view));
         }
     }
 
-    pub fn resize(&mut self, size: Size) {
+    pub fn resize(&self, size: Size) {
         if self.inner.state.closed.get() {
             return;
         }

--- a/src/platform/win/window.rs
+++ b/src/platform/win/window.rs
@@ -13,8 +13,7 @@ use windows_sys::Win32::{
     },
 };
 
-use std::cell::{Cell, Ref, RefCell};
-use std::collections::VecDeque;
+use std::cell::{Cell, OnceCell, Ref, RefCell};
 use std::num::NonZeroUsize;
 use std::ptr::null_mut;
 use std::rc::Rc;
@@ -173,7 +172,7 @@ impl WindowImpl for BaseviewWindow {
 
             self.handler_builder.take().unwrap()(&mut window)
         };
-        *window_state.handler.borrow_mut() = Some(handler);
+        let Ok(()) = window_state.handler.set(handler) else { unreachable!() };
 
         if dpi_changed {
             // Send an initial Resized event so users get the correct scale factor and physical size.
@@ -186,24 +185,7 @@ impl WindowImpl for BaseviewWindow {
     unsafe fn handle_message(
         &self, window: HWnd, msg: u32, wparam: WPARAM, lparam: LPARAM,
     ) -> Option<LRESULT> {
-        let result = unsafe { wnd_proc_inner(window, msg, wparam, lparam, &self.window_state) };
-
-        // If any of the above event handlers caused tasks to be pushed to the deferred tasks list,
-        // then we'll try to handle them now
-        loop {
-            // NOTE: This is written like this instead of using a `while let` loop to avoid exending
-            //       the borrow of `window_state.deferred_tasks` into the call of
-            //       `window_state.handle_deferred_task()` since that may also generate additional
-            //       messages.
-            let task = match self.window_state.deferred_tasks.borrow_mut().pop_front() {
-                Some(task) => task,
-                None => break,
-            };
-
-            self.window_state.handle_deferred_task(task, window);
-        }
-
-        result
+        unsafe { wnd_proc_inner(window, msg, wparam, lparam, &self.window_state) }
     }
 
     fn before_destroy(&self, window: HWnd) {
@@ -453,15 +435,9 @@ unsafe fn wnd_proc_inner(
     }
 }
 
-/// All data associated with the window. This uses internal mutability so the outer struct doesn't
-/// need to be mutably borrowed. Mutably borrowing the entire `WindowState` can be problematic
-/// because of the Windows message loops' reentrant nature. Care still needs to be taken to prevent
-/// `handler` from indirectly triggering other events that would also need to be handled using
-/// `handler`.
+/// All data associated with the window.
 pub(crate) struct WindowState {
-    /// The HWND belonging to this window. The window's actual state is stored in the `WindowState`
-    /// struct associated with this HWND through `unsafe { GetWindowLongPtrW(self.hwnd,
-    /// GWLP_USERDATA) } as *const WindowState`.
+    /// The HWND belonging to this window.
     pub hwnd: HWND,
     current_size: Cell<PhySize>,
     current_dpi: Cell<Dpi>, // None if in non-system scale policy
@@ -470,20 +446,13 @@ pub(crate) struct WindowState {
     mouse_was_outside_window: Cell<bool>,
     cursor_icon: Cell<MouseCursor>,
     // Initialized late so the `Window` can hold a reference to this `WindowState`
-    handler: Option<Box<dyn WindowHandler>>,
+    handler: OnceCell<Box<dyn WindowHandler>>,
     scale_policy: WindowScalePolicy,
 
     user32: ExtendedUser32,
 
-    /// Tasks that should be executed at the end of `wnd_proc`. This is needed to avoid mutably
-    /// borrowing the fields from `WindowState` more than once. For instance, when the window
-    /// handler requests a resize in response to a keyboard event, the window state will already be
-    /// borrowed in `wnd_proc`. So the `resize()` function below cannot also mutably borrow that
-    /// window state at the same time.
-    pub deferred_tasks: RefCell<VecDeque<WindowTask>>,
-
     #[cfg(feature = "opengl")]
-    pub gl_context: core::cell::OnceCell<crate::gl::GlContext>,
+    pub gl_context: OnceCell<crate::gl::GlContext>,
 }
 
 impl WindowState {
@@ -498,29 +467,24 @@ impl WindowState {
             mouse_button_counter: Cell::new(0),
             mouse_was_outside_window: true.into(),
             cursor_icon: Cell::new(MouseCursor::Default),
-            handler: RefCell::new(None),
+            handler: OnceCell::new(),
             scale_policy,
             user32,
 
-            deferred_tasks: RefCell::new(VecDeque::with_capacity(4)),
-
             #[cfg(feature = "opengl")]
-            gl_context: core::cell::OnceCell::new(),
+            gl_context: OnceCell::new(),
         }
     }
 
     pub(crate) fn handle_on_frame(&self) {
-        let mut handler = self.handler.borrow_mut();
-        let Some(handler) = handler.as_mut() else { return };
+        let Some(handler) = self.handler.get() else { return };
         let mut window = crate::window::Window::new(Window { state: self });
 
         handler.on_frame(&mut window)
     }
 
     pub(crate) fn handle_event(&self, event: Event) -> EventStatus {
-        let mut handler = self.handler.borrow_mut();
-
-        let Some(handler) = handler.as_mut() else {
+        let Some(handler) = self.handler.get() else {
             return EventStatus::Ignored;
         };
 
@@ -546,33 +510,6 @@ impl WindowState {
     fn send_resized(&self) {
         self.handle_event(Event::Window(WindowEvent::Resized(self.window_info())));
     }
-
-    /// Handle a deferred task as described in [`Self::deferred_tasks`].
-    pub(self) fn handle_deferred_task(&self, task: WindowTask, window: HWnd) {
-        match task {
-            WindowTask::Resize(size) => {
-                // `self.window_info` will be modified in response to the `WM_SIZE` event that
-                // follows the `SetWindowPos()` call
-                let dpi = self.current_dpi.get();
-                let window_info = WindowInfo::from_logical_size(size, dpi.scale_factor());
-                let new_size = window_info.physical_size();
-
-                window.resize_and_activate(new_size, dpi, &self.user32).unwrap();
-            }
-            WindowTask::Focus => window.set_focus().unwrap(),
-        }
-    }
-}
-
-/// Tasks that must be deferred until the end of [`wnd_proc()`] to avoid reentrant `WindowState`
-/// borrows. See the docstring on [`WindowState::deferred_tasks`] for more information.
-#[derive(Debug, Clone)]
-pub(crate) enum WindowTask {
-    /// Resize the window to the given size. The size is in logical pixels. DPI scaling is applied
-    /// automatically.
-    Resize(Size),
-    /// Request keyboard focus for the window.
-    Focus,
 }
 
 pub struct Window<'a> {
@@ -690,16 +627,22 @@ impl Window<'_> {
     }
 
     pub fn focus(&self) {
-        // To avoid reentrant event handler calls we'll defer the actual focus request until after
-        // the event has been handled
-        self.state.deferred_tasks.borrow_mut().push_back(WindowTask::Focus);
+        self.hwnd().set_focus().unwrap()
+    }
+
+    fn hwnd(&self) -> HWnd<'_> {
+        // SAFETY: this handle should be safe to use
+        unsafe { HWnd::from_raw(self.state.hwnd) }
     }
 
     pub fn resize(&self, size: Size) {
-        // To avoid reentrant event handler calls we'll defer the actual resizing until after the
-        // event has been handled
-        let task = WindowTask::Resize(size);
-        self.state.deferred_tasks.borrow_mut().push_back(task);
+        // `self.window_info` will be modified in response to the `WM_SIZE` event that
+        // follows the `SetWindowPos()` call
+        let scaling = self.state.current_scale_factor.get();
+        let window_info = WindowInfo::from_logical_size(size, scaling);
+        let new_size = window_info.physical_size();
+
+        self.hwnd().resize_and_activate(new_size, self.state.dw_style).unwrap();
     }
 
     pub fn set_mouse_cursor(&self, mouse_cursor: MouseCursor) {

--- a/src/platform/win/window.rs
+++ b/src/platform/win/window.rs
@@ -638,11 +638,11 @@ impl Window<'_> {
     pub fn resize(&self, size: Size) {
         // `self.window_info` will be modified in response to the `WM_SIZE` event that
         // follows the `SetWindowPos()` call
-        let scaling = self.state.current_scale_factor.get();
-        let window_info = WindowInfo::from_logical_size(size, scaling);
+        let dpi = self.state.current_dpi.get();
+        let window_info = WindowInfo::from_logical_size(size, dpi.scale_factor());
         let new_size = window_info.physical_size();
 
-        self.hwnd().resize_and_activate(new_size, self.state.dw_style).unwrap();
+        self.hwnd().resize_and_activate(new_size, dpi, &self.state.user32).unwrap();
     }
 
     pub fn set_mouse_cursor(&self, mouse_cursor: MouseCursor) {

--- a/src/platform/win/window.rs
+++ b/src/platform/win/window.rs
@@ -58,12 +58,12 @@ const WIN_FRAME_TIMER: NonZeroUsize = match NonZeroUsize::new(4242) {
 };
 
 pub struct WindowHandle {
-    hwnd: Option<HWND>,
+    hwnd: Cell<Option<HWND>>,
     is_open: Rc<Cell<bool>>,
 }
 
 impl WindowHandle {
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         if let Some(hwnd) = self.hwnd.take() {
             unsafe {
                 PostMessageW(hwnd, BV_WINDOW_MUST_CLOSE, 0, 0);
@@ -78,7 +78,7 @@ impl WindowHandle {
 
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        if let Some(hwnd) = self.hwnd {
+        if let Some(hwnd) = self.hwnd.get() {
             let mut handle = Win32WindowHandle::empty();
             handle.hwnd = hwnd;
 
@@ -470,7 +470,7 @@ pub(crate) struct WindowState {
     mouse_was_outside_window: Cell<bool>,
     cursor_icon: Cell<MouseCursor>,
     // Initialized late so the `Window` can hold a reference to this `WindowState`
-    handler: RefCell<Option<Box<dyn WindowHandler>>>,
+    handler: Option<Box<dyn WindowHandler>>,
     scale_policy: WindowScalePolicy,
 
     user32: ExtendedUser32,
@@ -676,33 +676,33 @@ impl Window<'_> {
 
         window.show_and_activate();
 
-        WindowHandle { hwnd: Some(hwnd), is_open: Rc::clone(&is_open) }
+        WindowHandle { hwnd: Some(hwnd).into(), is_open: Rc::clone(&is_open) }
     }
 
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         unsafe {
             PostMessageW(self.state.hwnd, BV_WINDOW_MUST_CLOSE, 0, 0);
         }
     }
 
-    pub fn has_focus(&mut self) -> bool {
+    pub fn has_focus(&self) -> bool {
         HWnd::get_focused_window() == self.state.hwnd
     }
 
-    pub fn focus(&mut self) {
+    pub fn focus(&self) {
         // To avoid reentrant event handler calls we'll defer the actual focus request until after
         // the event has been handled
         self.state.deferred_tasks.borrow_mut().push_back(WindowTask::Focus);
     }
 
-    pub fn resize(&mut self, size: Size) {
+    pub fn resize(&self, size: Size) {
         // To avoid reentrant event handler calls we'll defer the actual resizing until after the
         // event has been handled
         let task = WindowTask::Resize(size);
         self.state.deferred_tasks.borrow_mut().push_back(task);
     }
 
-    pub fn set_mouse_cursor(&mut self, mouse_cursor: MouseCursor) {
+    pub fn set_mouse_cursor(&self, mouse_cursor: MouseCursor) {
         self.state.cursor_icon.set(mouse_cursor);
         if let Ok(cursor) = SystemCursor::load(mouse_cursor) {
             cursor.set()

--- a/src/platform/x11/window.rs
+++ b/src/platform/x11/window.rs
@@ -33,13 +33,13 @@ use super::{event_loop::EventLoop, visual_info::WindowVisualConfig};
 
 pub struct WindowHandle {
     raw_window_handle: Option<RawWindowHandle>,
-    event_loop_handle: Option<JoinHandle<()>>,
+    event_loop_handle: Cell<Option<JoinHandle<()>>>,
     close_requested: Arc<AtomicBool>,
     is_open: Arc<AtomicBool>,
 }
 
 impl WindowHandle {
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         self.close_requested.store(true, Ordering::Relaxed);
         if let Some(event_loop) = self.event_loop_handle.take() {
             let _ = event_loop.join();
@@ -74,7 +74,7 @@ impl ParentHandle {
         let is_open = Arc::new(AtomicBool::new(true));
         let handle = WindowHandle {
             raw_window_handle: None,
-            event_loop_handle: None,
+            event_loop_handle: None.into(),
             close_requested: Arc::clone(&close_requested),
             is_open: Arc::clone(&is_open),
         };
@@ -143,7 +143,7 @@ impl<'a> Window<'a> {
 
         let raw_window_handle = rx.recv().unwrap().unwrap();
         window_handle.raw_window_handle = Some(raw_window_handle.0);
-        window_handle.event_loop_handle = Some(join_handle);
+        window_handle.event_loop_handle = Some(join_handle).into();
         window_handle
     }
 
@@ -302,7 +302,7 @@ impl<'a> Window<'a> {
 
         let mut window = crate::Window::new(Window { inner: &mut inner });
 
-        let mut handler = build(&mut window);
+        let handler = build(&mut window);
 
         // Send an initial window resized event so the user is alerted of
         // the correct dpi scaling.
@@ -333,7 +333,7 @@ impl<'a> Window<'a> {
         self.inner.mouse_cursor.set(mouse_cursor);
     }
 
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         self.inner.close_requested.set(true);
     }
 
@@ -350,7 +350,7 @@ impl<'a> Window<'a> {
         let _ = self.inner.xcb_connection.conn.flush();
     }
 
-    pub fn resize(&mut self, size: Size) {
+    pub fn resize(&self, size: Size) {
         let scaling = self.inner.window_info.scale();
         let new_window_info = WindowInfo::from_logical_size(size, scaling);
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -20,7 +20,7 @@ impl WindowHandle {
     }
 
     /// Close the window
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         self.window_handle.close();
     }
 
@@ -38,8 +38,8 @@ unsafe impl HasRawWindowHandle for WindowHandle {
 }
 
 pub trait WindowHandler {
-    fn on_frame(&mut self, window: &mut Window);
-    fn on_event(&mut self, window: &mut Window, event: Event) -> EventStatus;
+    fn on_frame(&self, window: &mut Window);
+    fn on_event(&self, window: &mut Window, event: Event) -> EventStatus;
 }
 
 pub struct Window<'a> {
@@ -81,25 +81,25 @@ impl<'a> Window<'a> {
     }
 
     /// Close the window
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         self.window.close();
     }
 
     /// Resize the window to the given size. The size is always in logical pixels. DPI scaling will
     /// automatically be accounted for.
-    pub fn resize(&mut self, size: Size) {
+    pub fn resize(&self, size: Size) {
         self.window.resize(size);
     }
 
-    pub fn set_mouse_cursor(&mut self, cursor: MouseCursor) {
+    pub fn set_mouse_cursor(&self, cursor: MouseCursor) {
         self.window.set_mouse_cursor(cursor);
     }
 
-    pub fn has_focus(&mut self) -> bool {
+    pub fn has_focus(&self) -> bool {
         self.window.has_focus()
     }
 
-    pub fn focus(&mut self) {
+    pub fn focus(&self) {
         self.window.focus()
     }
 


### PR DESCRIPTION
This PR allows the `WindowHandler`'s methods to be called re-entrantly, which allows for natural platform behavior on Windows and macOS.

This is done by changing the `WindowHandler` methods' signatures to only take `&self` instead of `&mut self`. This makes it so baseview users need to use interior mutability in their types (`Cell`, `OnceCell`, `RefCell`, etc.).

While this increases complexity for users, this allows for more granularity in the borrows (rather than `baseview` attempting to prevent reentrancy, and trying to mutably borrow the whole `WindowHandler` for each event).

This also allows for downstream users to perform any kind of action in any kind of handler (e.g. resizing the window on click in a menu), without having to "defer" anything.