### PR TITLE
X11: Fix PlatformHandle

### DIFF
--- a/examples/render_wgpu/Cargo.toml
+++ b/examples/render_wgpu/Cargo.toml
@@ -6,5 +6,7 @@ publish = false
 
 [dependencies]
 baseview = { path = "../..", features = ["opengl"] }
-wgpu = "29.0.3"
+wgpu = "30.0.0"
+env_logger = "0.11.11"
+log = "0.4.33"
 pollster = "0.4.0"

--- a/examples/render_wgpu/src/main.rs
+++ b/examples/render_wgpu/src/main.rs
@@ -3,6 +3,7 @@ use baseview::{
     Event, EventStatus, Window, WindowContext, WindowHandler, WindowOpenOptions, WindowSize,
 };
 
+use log::LevelFilter;
 use std::cell::RefCell;
 
 struct WgpuExample {
@@ -30,6 +31,7 @@ impl WgpuExample {
                 force_fallback_adapter: false,
                 // Request an adapter which can render to our surface
                 compatible_surface: Some(&surface),
+                ..Default::default()
             })
             .await
             .expect("Failed to find an appropriate adapter");
@@ -182,7 +184,7 @@ impl WindowHandler for WgpuExample {
         }
 
         self.queue.submit(Some(encoder.finish()));
-        surface_texture.present();
+        self.queue.present(surface_texture);
     }
 
     fn resized(&self, new_size: WindowSize) {
@@ -203,6 +205,7 @@ impl WindowHandler for WgpuExample {
 }
 
 fn main() {
+    env_logger::builder().filter_level(LevelFilter::Debug).init();
     let window_open_options = WindowOpenOptions::new()
         .with_title("WGPU on Baseview")
         .with_size(LogicalSize::new(512, 512));

--- a/src/platform/x11/mod.rs
+++ b/src/platform/x11/mod.rs
@@ -30,16 +30,18 @@ pub mod gl;
 pub struct PlatformHandle {
     connection: Arc<XlibXcbConnection>,
     window_id: NonZero<x11rb::protocol::xproto::Window>,
+    visual_id: NonZero<x11rb::protocol::xproto::Visualid>,
 }
 
 impl PlatformHandle {
     pub fn window_handle(&self) -> Option<raw_window_handle::WindowHandle<'_>> {
-        let handle = XcbWindowHandle::new(self.window_id);
+        let mut handle = XcbWindowHandle::new(self.window_id);
+        handle.visual_id = Some(self.visual_id);
         Some(unsafe { raw_window_handle::WindowHandle::borrow_raw(handle.into()) })
     }
 
     pub fn display_handle(&self) -> DisplayHandle<'_> {
-        self.connection.display_handle()
+        self.connection.xcb_display_handle()
     }
 }
 

--- a/src/platform/x11/window.rs
+++ b/src/platform/x11/window.rs
@@ -236,6 +236,7 @@ impl Window {
             window_id,
             physical_size,
             scaling,
+            visual_info.visual_id.try_into()?,
             #[cfg(feature = "opengl")]
             gl_context,
         ));

--- a/src/platform/x11/window_shared.rs
+++ b/src/platform/x11/window_shared.rs
@@ -8,7 +8,8 @@ use std::rc::Rc;
 use std::sync::Arc;
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::{
-    ChangeWindowAttributesAux, ConfigureWindowAux, ConnectionExt, InputFocus, Window as XWindow,
+    ChangeWindowAttributesAux, ConfigureWindowAux, ConnectionExt, InputFocus, Visualid,
+    Window as XWindow,
 };
 use x11rb::CURRENT_TIME;
 
@@ -22,6 +23,7 @@ pub(crate) struct WindowInner {
     pub(crate) scaling_factor: Cell<f64>,
     pub(crate) window_size: Cell<PhysicalSize<u16>>,
     mouse_cursor: Cell<MouseCursor>,
+    pub(crate) visual_id: NonZero<Visualid>,
 
     pub(crate) close_requested: Cell<bool>,
     pub(crate) is_focused: Cell<bool>,
@@ -30,11 +32,13 @@ pub(crate) struct WindowInner {
 impl WindowInner {
     pub(crate) fn new(
         connection: Rc<X11Connection>, window_id: NonZero<XWindow>, window_size: PhysicalSize<u16>,
-        scale_factor: f64, #[cfg(feature = "opengl")] gl_context: Option<super::gl::GlContext>,
+        scale_factor: f64, visual_id: NonZero<Visualid>,
+        #[cfg(feature = "opengl")] gl_context: Option<super::gl::GlContext>,
     ) -> Self {
         Self {
             connection,
             window_id,
+            visual_id,
             window_size: window_size.into(),
             scaling_factor: scale_factor.into(),
             mouse_cursor: MouseCursor::default().into(),
@@ -98,18 +102,20 @@ impl WindowInner {
     }
 
     pub fn window_handle(&self) -> Option<raw_window_handle::WindowHandle<'_>> {
-        let handle = XlibWindowHandle::new(self.window_id.get() as _);
+        let mut handle = XlibWindowHandle::new(self.window_id.get() as _);
+        handle.visual_id = self.visual_id.get().into();
         Some(unsafe { raw_window_handle::WindowHandle::borrow_raw(handle.into()) })
     }
 
     pub fn display_handle(&self) -> DisplayHandle<'_> {
-        self.connection.conn.display_handle()
+        self.connection.conn.xlib_display_handle()
     }
 
     pub fn platform_handle(&self) -> super::PlatformHandle {
         super::PlatformHandle {
             connection: Arc::clone(&self.connection.conn),
             window_id: self.window_id,
+            visual_id: self.visual_id,
         }
     }
 

--- a/src/wrappers/xlib/xlib_xcb.rs
+++ b/src/wrappers/xlib/xlib_xcb.rs
@@ -1,5 +1,5 @@
 use crate::wrappers::xlib::xlib_connection::XlibConnection;
-use raw_window_handle::{DisplayHandle, XlibDisplayHandle};
+use raw_window_handle::{DisplayHandle, XcbDisplayHandle, XlibDisplayHandle};
 use std::error::Error;
 use std::ops::Deref;
 use std::os::fd::{AsFd, BorrowedFd};
@@ -60,10 +60,18 @@ impl XlibXcbConnection {
         &self.xlib_connection
     }
 
-    pub fn display_handle(&self) -> DisplayHandle<'_> {
+    pub fn xlib_display_handle(&self) -> DisplayHandle<'_> {
         let raw_connection = self.xlib_connection.as_raw().cast();
         let Some(raw_connection) = NonNull::new(raw_connection) else { unreachable!() };
         let handle = XlibDisplayHandle::new(Some(raw_connection), self.default_screen());
+
+        unsafe { DisplayHandle::borrow_raw(handle.into()) }
+    }
+
+    pub fn xcb_display_handle(&self) -> DisplayHandle<'_> {
+        let raw_connection = self.xcb_connection.get_raw_xcb_connection();
+        let Some(raw_connection) = NonNull::new(raw_connection) else { unreachable!() };
+        let handle = XcbDisplayHandle::new(Some(raw_connection), self.default_screen());
 
         unsafe { DisplayHandle::borrow_raw(handle.into()) }
     }


### PR DESCRIPTION
This PR fixes PlatformHandle returning an XCBHandle and an XlibHandle as window and display handle respectively, which makes some libraries (Iced, WGPU in some cases) crash.

(and because this is clearly incorrect behavior 😅 )

The X11 handles now also properly provide the visual_id field.

This PR also updates the WGPU example to the latest version, and introduces env_logger in it.

This fixes #281.

