### PR TITLE
Fix Wine child window wglChoosePixelFormatARB not finding any formats

### DIFF
--- a/src/platform/win/gl.rs
+++ b/src/platform/win/gl.rs
@@ -240,7 +240,24 @@ impl GlContextInner {
             );
         }
 
+        // if no num_formats are found which happens in Wine for child windows, use fallback
         if num_formats == 0 {
+            let fallback_pfd = PIXELFORMATDESCRIPTOR {
+                nSize: std::mem::size_of::<PIXELFORMATDESCRIPTOR>() as u16,
+                nVersion: 1,
+                dwFlags: PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
+                iPixelType: PFD_TYPE_RGBA,
+                cColorBits: 32,
+                cAlphaBits: config.alpha_bits,
+                cDepthBits: config.depth_bits,
+                cStencilBits: config.stencil_bits,
+                iLayerType: PFD_MAIN_PLANE as u8,
+                ..std::mem::zeroed()
+            };
+            pixel_format = ChoosePixelFormat(hdc, &fallback_pfd);
+        }
+
+        if pixel_format == 0 {
             ReleaseDC(hwnd, hdc);
             return Err(GlError::CreationFailed(()));
         }


### PR DESCRIPTION
For embedded child windows in [Wine](https://www.winehq.org/), `wglChoosePixelFormatARB` can return `num_formats == 0` resulting in an error. When handling this by providing a fallback, the issue is resolved. One might argue that this is a Wine issue and is not to be fixed here, but this fix handles the case for me nicely and may benefit Rust developers on Linux that run Windows DAWs on Wine.

I bumped into this while developing a [nice-plug](https://codeberg.org/RustAudio/nice-plug) vst3 plugin and opening this in FL Studio running on Wine on Arch (Wayland + NVIDIA).

The full error FL Studio passed to me was:

```
Warning: sRGB framebuffer not supported, falling back to non-sRGB
03:06:54 [ERROR] thread 'unnamed' panicked at 'Could not create OpenGL context: CreationFailed(())': third_party/baseview/src/platform/win/window.rs:163
   0: backtrace::capture::Backtrace::create
   1: backtrace::capture::Backtrace::new
   2: nice_plug::wrapper::util::log_panics::{{closure}}
   3: std::panicking::panic_with_hook
   4: std::panicking::panic_handler::{closure#0}
   5: std::sys::backtrace::__rust_end_short_backtrace::<std::panicking::panic_handler::{closure#0}, !>
   6: __rustc::rust_begin_unwind
   7: core::panicking::panic_fmt
   8: core::result::unwrap_failed
   9: <baseview::platform::win::window::BaseviewWindow as baseview::wrappers::win32::window::WindowImpl>::after_create
  10: baseview::wrappers::win32::window::proc::wnd_proc
  11: <unknown>
  12: <unknown>
  13: <unknown>
  14: <unknown>
  15: <unknown>
  16: <unknown>
  17: <unknown>
  18: <nice_plug_egui::editor::EguiEditor<T> as nice_plug_core::editor::Editor>::spawn
  19: <ms_plugin::PanicGuardEditor as nice_plug_core::editor::Editor>::spawn
  20: vst3::bindings::Steinberg::IPlugView::make_vtbl::attached
  21: <unknown>
  22: <unknown>
  23: <unknown>
  24: <unknown>
  25: <unknown>
  26: <unknown>
  27: <unknown>
  28: <unknown>
  29: <unknown>
  30: <unknown>
  31: <unknown>
  32: <unknown>
  33: <unknown>
  34: <unknown>
  35: <unknown>
  36: <unknown>
  37: <unknown>
  38: <unknown>
  39: <unknown>
  40: <unknown>
  41: <unknown>
  42: <unknown>
  43: <unknown>
  44: <unknown>
  45: <unknown>
  46: <unknown>
  47: <unknown>
  48: <unknown>
  49: <unknown>
  50: <unknown>
  51: <unknown>

03:06:54 [ERROR] thread 'unnamed' panicked at 'panic in a function that cannot unwind': /rustc/31fca3adb283cc9dfd56b49cdee9a96eb9c96ffd/library\core\src\panicking.rs:225
   0: backtrace::capture::Backtrace::create
   1: backtrace::capture::Backtrace::new
   2: nice_plug::wrapper::util::log_panics::{{closure}}
   3: std::panicking::panic_with_hook
   4: std::panicking::panic_handler::{closure#0}
   5: std::sys::backtrace::__rust_end_short_backtrace::<std::panicking::panic_handler::{closure#0}, !>
   6: __rustc::rust_begin_unwind
   7: core::panicking::panic_nounwind_fmt
   8: core::panicking::panic_nounwind
   9: core::panicking::panic_cannot_unwind
  10: baseview::wrappers::win32::window::proc::wnd_proc
  11: <unknown>
  12: <unknown>
  13: <unknown>
  14: <unknown>
  15: <unknown>
  16: <unknown>
  17: <unknown>
  18: <nice_plug_egui::editor::EguiEditor<T> as nice_plug_core::editor::Editor>::spawn
  19: <ms_plugin::PanicGuardEditor as nice_plug_core::editor::Editor>::spawn
  20: vst3::bindings::Steinberg::IPlugView::make_vtbl::attached
  21: <unknown>
  22: <unknown>
  23: <unknown>
  24: <unknown>
  25: <unknown>
  26: <unknown>
  27: <unknown>
  28: <unknown>
  29: <unknown>
  30: <unknown>
  31: <unknown>
  32: <unknown>
  33: <unknown>
  34: <unknown>
  35: <unknown>
  36: <unknown>
  37: <unknown>
  38: <unknown>
  39: <unknown>
  40: <unknown>
  41: <unknown>
  42: <unknown>
  43: <unknown>
  44: <unknown>
  45: <unknown>
  46: <unknown>
  47: <unknown>
  48: <unknown>
  49: <unknown>
  50: <unknown>
  51: <unknown>

thread caused non-unwinding panic. aborting.
062c:err:seh:NtRaiseException Unhandled exception code c0000409 flags 1 addr 0x6ffff5e0db6d
```