### PR TITLE
Unified window creation

### DIFF
--- a/examples/open_parented/src/main.rs
+++ b/examples/open_parented/src/main.rs
@@ -1,7 +1,6 @@
 use baseview::dpi::LogicalSize;
 use baseview::{
-    Event, EventStatus, Window, WindowContext, WindowHandle, WindowHandler, WindowOpenOptions,
-    WindowSize,
+    Event, EventStatus, WindowContext, WindowHandle, WindowHandler, WindowOpenOptions, WindowSize,
 };
 use std::cell::{Cell, RefCell};
 use std::num::NonZeroU32;
@@ -24,10 +23,10 @@ impl ParentWindowHandler {
 
         let window_open_options = WindowOpenOptions::new()
             .with_size(LogicalSize::new(256, 256))
+            .with_parent(&window)
             .with_title("baseview child");
 
-        let child_window =
-            Window::open_parented(&window, window_open_options, ChildWindowHandler::new);
+        let child_window = baseview::create_window(window_open_options, ChildWindowHandler::new);
 
         Self { surface: surface.into(), damaged: true.into(), _child_window: Some(child_window) }
     }
@@ -122,5 +121,5 @@ impl WindowHandler for ChildWindowHandler {
 fn main() {
     let window_open_options = WindowOpenOptions::new().with_size(LogicalSize::new(512.0, 512.0));
 
-    Window::open_blocking(window_open_options, ParentWindowHandler::new);
+    baseview::create_window(window_open_options, ParentWindowHandler::new).run_until_closed();
 }

--- a/examples/open_window/src/main.rs
+++ b/examples/open_window/src/main.rs
@@ -8,8 +8,7 @@ use rtrb::{Consumer, RingBuffer};
 use baseview::copy_to_clipboard;
 use baseview::dpi::{LogicalSize, PhysicalPosition};
 use baseview::{
-    Event, EventStatus, MouseEvent, Window, WindowContext, WindowHandler, WindowOpenOptions,
-    WindowSize,
+    Event, EventStatus, MouseEvent, WindowContext, WindowHandler, WindowOpenOptions, WindowSize,
 };
 
 #[derive(Debug, Clone)]
@@ -148,7 +147,7 @@ fn main() {
         }
     });
 
-    Window::open_blocking(window_open_options, |window| {
+    baseview::create_window(window_open_options, |window| {
         let ctx = softbuffer::Context::new(window.clone()).unwrap();
         let mut surface = softbuffer::Surface::new(&ctx, window.clone()).unwrap();
         let size = window.size().physical;
@@ -164,7 +163,8 @@ fn main() {
             is_cursor_inside: false.into(),
             damaged: true.into(),
         }
-    });
+    })
+    .run_until_closed();
 }
 
 fn log_event(event: &Event) {

--- a/examples/render_femtovg/src/main.rs
+++ b/examples/render_femtovg/src/main.rs
@@ -1,8 +1,7 @@
 use baseview::dpi::{LogicalSize, PhysicalPosition};
 use baseview::gl::{GlConfig, GlContext};
 use baseview::{
-    Event, EventStatus, MouseEvent, Window, WindowContext, WindowHandler, WindowOpenOptions,
-    WindowSize,
+    Event, EventStatus, MouseEvent, WindowContext, WindowHandler, WindowOpenOptions, WindowSize,
 };
 use femtovg::renderer::OpenGl;
 use femtovg::{Canvas, Color};
@@ -117,7 +116,7 @@ fn main() {
         .with_size(LogicalSize::new(512, 512))
         .with_gl_config(GlConfig { alpha_bits: 8, ..GlConfig::default() });
 
-    Window::open_blocking(window_open_options, FemtovgExample::new);
+    baseview::create_window(window_open_options, FemtovgExample::new).run_until_closed();
 }
 
 fn log_event(event: &Event) {

--- a/examples/render_wgpu/src/main.rs
+++ b/examples/render_wgpu/src/main.rs
@@ -1,7 +1,5 @@
 use baseview::dpi::{LogicalSize, PhysicalSize};
-use baseview::{
-    Event, EventStatus, Window, WindowContext, WindowHandler, WindowOpenOptions, WindowSize,
-};
+use baseview::{Event, EventStatus, WindowContext, WindowHandler, WindowOpenOptions, WindowSize};
 
 use log::LevelFilter;
 use std::cell::RefCell;
@@ -210,7 +208,8 @@ fn main() {
         .with_title("WGPU on Baseview")
         .with_size(LogicalSize::new(512, 512));
 
-    Window::open_blocking(window_open_options, |c| pollster::block_on(WgpuExample::new(c)));
+    baseview::create_window(window_open_options, |c| pollster::block_on(WgpuExample::new(c)))
+        .run_until_closed();
 }
 
 fn log_event(event: &Event) {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,7 +1,24 @@
-use crate::{Event, EventStatus, WindowSize};
+use super::*;
 
 pub trait WindowHandler: 'static {
     fn on_frame(&self);
     fn resized(&self, new_size: WindowSize);
     fn on_event(&self, event: Event) -> EventStatus;
+}
+
+#[allow(unused)]
+pub struct WindowHandlerBuilder {
+    inner: Box<dyn FnOnce(WindowContext) -> Box<dyn WindowHandler> + Send + 'static>,
+}
+
+impl WindowHandlerBuilder {
+    pub fn new<H: WindowHandler>(
+        f: impl FnOnce(WindowContext) -> H + Send + 'static,
+    ) -> WindowHandlerBuilder {
+        Self { inner: Box::new(|c| Box::new(f(c))) }
+    }
+
+    pub fn build(self, ctx: WindowContext) -> Box<dyn WindowHandler> {
+        (self.inner)(ctx)
+    }
 }

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -5,12 +5,14 @@ mod view;
 mod window;
 
 use crate::platform::macos::view::BaseviewView;
-use crate::wrappers::appkit::View;
+use crate::wrappers::appkit::{extract_raw_window_handle, View};
 pub use context::WindowContext;
 use dispatch2::MainThreadBound;
+use objc2::__framework_prelude::Retained;
 use objc2::rc::Weak;
 use objc2::MainThreadMarker;
-use raw_window_handle::DisplayHandle;
+use objc2_app_kit::NSView;
+use raw_window_handle::{DisplayHandle, HasWindowHandle};
 use std::fmt;
 use std::fmt::Formatter;
 pub use window::*;
@@ -61,5 +63,16 @@ impl fmt::Debug for PlatformHandle {
         }
 
         f.debug_struct("PlatformHandle (AppKit)").field("ns_view", &PtrFmt(self)).finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParentWindowHandle {
+    view: Retained<NSView>,
+}
+
+impl ParentWindowHandle {
+    pub fn extract(window: &impl HasWindowHandle) -> Self {
+        Self { view: extract_raw_window_handle(window.window_handle().unwrap()).unwrap() }
     }
 }

--- a/src/platform/macos/view.rs
+++ b/src/platform/macos/view.rs
@@ -2,6 +2,7 @@
 
 use super::keyboard::{make_modifiers, KeyboardState};
 use super::window::WindowSharedState;
+use crate::handler::WindowHandlerBuilder;
 use crate::platform::macos::context::WindowContext;
 use crate::wrappers::appkit::*;
 use crate::MouseEvent::{ButtonPressed, ButtonReleased};
@@ -44,10 +45,9 @@ pub(crate) struct BaseviewView {
 }
 
 impl BaseviewView {
-    pub fn new<H: WindowHandler + 'static>(
-        _options: WindowOpenOptions,
-        builder: impl FnOnce(crate::WindowContext) -> H + Send + 'static,
-        parenting: ViewParentingType, final_size: LogicalSize<f64>, mtm: MainThreadMarker,
+    pub fn new(
+        _options: WindowOpenOptions, builder: WindowHandlerBuilder, parenting: ViewParentingType,
+        final_size: LogicalSize<f64>, mtm: MainThreadMarker,
     ) -> (Retained<View<Self>>, Rc<WindowSharedState>) {
         let view_rect =
             NSRect::new(NSPoint::ZERO, NSSize::new(final_size.width, final_size.height));
@@ -92,7 +92,7 @@ impl BaseviewView {
             }
 
             let context = WindowContext::new(view);
-            let handler = Box::new(builder(crate::WindowContext::new(context)));
+            let handler = builder.build(crate::WindowContext::new(context));
 
             // Initialize handler
             let Ok(()) = view.window_handler.set(handler) else { unreachable!() };

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -1,26 +1,83 @@
 use dpi::LogicalSize;
-use objc2::rc::{autoreleasepool, Weak};
+use objc2::rc::{autoreleasepool, Retained, Weak};
 use objc2::MainThreadMarker;
-use objc2_app_kit::{
-    NSApplication, NSApplicationActivationPolicy, NSPasteboard, NSPasteboardTypeString,
-};
+use objc2_app_kit::{NSApplication, NSPasteboard, NSPasteboardTypeString, NSView, NSWindow};
 use objc2_foundation::{NSSize, NSString};
-use raw_window_handle::HasWindowHandle;
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
+use std::error::Error;
 use std::rc::Rc;
 
+use crate::handler::WindowHandlerBuilder;
 use crate::platform::macos::view::{BaseviewView, ViewParentingType};
-use crate::wrappers::appkit::{create_window, extract_raw_window_handle, View};
-use crate::{WindowContext, WindowHandler, WindowOpenOptions};
+use crate::wrappers::appkit::{create_window, View};
+use crate::*;
 
 pub struct WindowHandle {
-    view: RefCell<Option<Weak<View<BaseviewView>>>>,
+    mtm: MainThreadMarker,
+    view: Weak<View<BaseviewView>>,
+    window: Option<Retained<NSWindow>>,
     state: Rc<WindowSharedState>,
 }
 
 impl WindowHandle {
+    pub fn create_window(mut options: WindowOpenOptions, handler: WindowHandlerBuilder) -> Self {
+        autoreleasepool(|_| {
+            let Some(mtm) = MainThreadMarker::new() else {
+                panic!("macOS: Windows can only be created on the main thread!")
+            };
+
+            // Creates the global NSApplication instance, if it doesn't exist yet
+            let _ = NSApplication::sharedApplication(mtm);
+
+            if let Some(parent) = options.parent.take() {
+                return Self::create_window_parented(options, handler, parent.view, mtm);
+            }
+
+            Self::create_window_standalone(options, handler, mtm)
+        })
+    }
+
+    pub fn create_window_parented(
+        builder: WindowOpenOptions, handler: WindowHandlerBuilder, parent_view: Retained<NSView>,
+        mtm: MainThreadMarker,
+    ) -> Self {
+        let parenting =
+            ViewParentingType::Parented { parent_view: Weak::from_retained(&parent_view) };
+
+        let backing_scale_factor =
+            parent_view.window().map(|w| w.backingScaleFactor()).unwrap_or(1.0);
+        let final_size = builder.size.to_logical(backing_scale_factor);
+
+        let (ns_view, state) = BaseviewView::new(builder, handler, parenting, final_size, mtm);
+
+        Self { mtm, state, window: None, view: Weak::from_retained(&ns_view) }
+    }
+
+    pub fn create_window_standalone(
+        builder: WindowOpenOptions, handler: WindowHandlerBuilder, mtm: MainThreadMarker,
+    ) -> Self {
+        let app = NSApplication::sharedApplication(mtm);
+        let window = create_window_with_options(&builder, mtm);
+
+        let final_size = window.contentRectForFrameRect(window.frame()).size;
+        let final_size = LogicalSize::new(final_size.width, final_size.height);
+
+        let parenting = ViewParentingType::Windowed {
+            running_app: Weak::from_retained(&app),
+            owned_window: Weak::from_retained(&window),
+        };
+
+        let (view, state) = BaseviewView::new(builder, handler, parenting, final_size, mtm);
+
+        Self { mtm, state, view: Weak::from_retained(&view), window: Some(window) }
+    }
+
+    pub fn run_until_closed(self) {
+        NSApplication::sharedApplication(self.mtm).run();
+    }
+
     pub fn close(&self) {
-        let Some(view) = self.view.take().and_then(|w| w.load()) else {
+        let Some(view) = self.view.load() else {
             return;
         };
 
@@ -32,72 +89,23 @@ impl WindowHandle {
     }
 }
 
-pub struct Window;
+fn create_window_with_options(
+    options: &WindowOpenOptions, mtm: MainThreadMarker,
+) -> Retained<NSWindow> {
+    let initial_size = options.size.to_logical(1.0);
+    let window = create_window(initial_size, mtm);
+    window.center();
 
-impl Window {
-    pub fn open_parented<H: WindowHandler>(
-        parent: &impl HasWindowHandle, options: WindowOpenOptions,
-        build: impl FnOnce(WindowContext) -> H + Send + 'static,
-    ) -> WindowHandle {
-        autoreleasepool(|_| {
-            let Some(parent_view) = extract_raw_window_handle(parent.window_handle().unwrap())
-            else {
-                panic!("Invalid window handle: ns_view is NULL");
-            };
-
-            let Some(mtm) = MainThreadMarker::new() else {
-                panic!("macOS: open_blocking can only be called on the main thread!")
-            };
-
-            let parenting =
-                ViewParentingType::Parented { parent_view: Weak::from_retained(&parent_view) };
-
-            let backing_scale_factor =
-                parent_view.window().map(|w| w.backingScaleFactor()).unwrap_or(1.0);
-            let final_size = options.size.to_logical(backing_scale_factor);
-
-            let (ns_view, state) = BaseviewView::new(options, build, parenting, final_size, mtm);
-
-            WindowHandle { view: Some(Weak::from_retained(&ns_view)).into(), state }
-        })
+    let final_size = options.size.to_logical(window.backingScaleFactor());
+    if final_size != initial_size {
+        window.setContentSize(NSSize::new(final_size.width, final_size.height));
     }
 
-    pub fn open_blocking<H: WindowHandler>(
-        options: WindowOpenOptions, build: impl FnOnce(WindowContext) -> H + Send + 'static,
-    ) {
-        autoreleasepool(|_| {
-            let Some(mtm) = MainThreadMarker::new() else {
-                panic!("macOS: open_blocking can only be called on the main thread!")
-            };
+    let title = NSString::from_str(&options.title);
+    window.setTitle(&title);
 
-            // Creates the global NSApplication instance, if it doesn't exist yet
-            let app = NSApplication::sharedApplication(mtm);
-
-            let _ = app.setActivationPolicy(NSApplicationActivationPolicy::Regular);
-
-            let initial_size = options.size.to_logical(1.0);
-            let window = create_window(initial_size, mtm);
-            window.center();
-
-            let final_size = options.size.to_logical(window.backingScaleFactor());
-            if final_size != initial_size {
-                window.setContentSize(NSSize::new(final_size.width, final_size.height));
-            }
-
-            let title = NSString::from_str(&options.title);
-            window.setTitle(&title);
-            window.makeKeyAndOrderFront(None);
-
-            let parenting = ViewParentingType::Windowed {
-                running_app: Weak::from_retained(&app),
-                owned_window: Weak::from_retained(&window),
-            };
-
-            let _ = BaseviewView::new(options, build, parenting, final_size, mtm);
-
-            app.run();
-        })
-    }
+    window.makeKeyAndOrderFront(None);
+    window
 }
 
 pub(crate) struct WindowSharedState {

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -4,7 +4,6 @@ use objc2::MainThreadMarker;
 use objc2_app_kit::{NSApplication, NSPasteboard, NSPasteboardTypeString, NSView, NSWindow};
 use objc2_foundation::{NSSize, NSString};
 use std::cell::Cell;
-use std::error::Error;
 use std::rc::Rc;
 
 use crate::handler::WindowHandlerBuilder;
@@ -15,7 +14,7 @@ use crate::*;
 pub struct WindowHandle {
     mtm: MainThreadMarker,
     view: Weak<View<BaseviewView>>,
-    window: Option<Retained<NSWindow>>,
+    _window: Option<Retained<NSWindow>>,
     state: Rc<WindowSharedState>,
 }
 
@@ -50,7 +49,7 @@ impl WindowHandle {
 
         let (ns_view, state) = BaseviewView::new(builder, handler, parenting, final_size, mtm);
 
-        Self { mtm, state, window: None, view: Weak::from_retained(&ns_view) }
+        Self { mtm, state, _window: None, view: Weak::from_retained(&ns_view) }
     }
 
     pub fn create_window_standalone(
@@ -69,7 +68,7 @@ impl WindowHandle {
 
         let (view, state) = BaseviewView::new(builder, handler, parenting, final_size, mtm);
 
-        Self { mtm, state, view: Weak::from_retained(&view), window: Some(window) }
+        Self { mtm, state, view: Weak::from_retained(&view), _window: Some(window) }
     }
 
     pub fn run_until_closed(self) {

--- a/src/platform/win/mod.rs
+++ b/src/platform/win/mod.rs
@@ -44,6 +44,7 @@ impl Debug for PlatformHandle {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct ParentWindowHandle {
     handle: HWnd,
 }

--- a/src/platform/win/mod.rs
+++ b/src/platform/win/mod.rs
@@ -5,7 +5,8 @@ mod window;
 mod window_state;
 
 use crate::wrappers::win32::h_instance::HInstance;
-use raw_window_handle::{DisplayHandle, Win32WindowHandle};
+use crate::wrappers::win32::window::HWnd;
+use raw_window_handle::{DisplayHandle, HasWindowHandle, RawWindowHandle, Win32WindowHandle};
 use std::fmt::Debug;
 use std::num::NonZeroIsize;
 use std::rc::Rc;
@@ -40,5 +41,20 @@ impl Debug for PlatformHandle {
             .field("hwnd", &self.hwnd.get())
             .field("hinstance", &HInstance::get_from_dll().addr().get())
             .finish()
+    }
+}
+
+pub struct ParentWindowHandle {
+    handle: HWnd,
+}
+
+impl ParentWindowHandle {
+    pub fn extract(parent: &impl HasWindowHandle) -> Self {
+        let parent = match parent.window_handle().unwrap().as_raw() {
+            RawWindowHandle::Win32(h) => h.hwnd,
+            h => panic!("unsupported parent handle {:?}", h),
+        };
+
+        Self { handle: unsafe { HWnd::from_raw(parent.get() as _) } }
     }
 }

--- a/src/platform/win/window.rs
+++ b/src/platform/win/window.rs
@@ -14,26 +14,24 @@ use windows_sys::Win32::{
 };
 
 use dpi::{PhysicalPosition, PhysicalSize, Size};
-use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use std::cell::Cell;
 use std::num::NonZeroUsize;
-use std::ptr::null_mut;
 
 pub(crate) const BV_WINDOW_MUST_CLOSE: u32 = WM_USER + 1;
 
 use super::drop_target::DropTarget;
 use super::*;
+use crate::handler::WindowHandlerBuilder;
 use crate::platform::win::window_state::WindowState;
 use crate::wrappers::win32::cursor::SystemCursor;
-use crate::{
-    Event, MouseButton, MouseEvent, ScrollDelta, WindowEvent, WindowHandler, WindowOpenOptions,
-    WindowScalePolicy, WindowSize,
-};
-
 use crate::wrappers::win32::window::*;
 use crate::wrappers::win32::{
     ole_initialize, run_thread_message_loop_until, Dpi, DpiAwarenessContext, ExtendedUser32, Rect,
     WindowStyle,
+};
+use crate::{
+    Event, MouseButton, MouseEvent, ScrollDelta, WindowEvent, WindowHandler, WindowOpenOptions,
+    WindowScalePolicy, WindowSize,
 };
 
 #[allow(non_snake_case)]
@@ -57,6 +55,10 @@ pub struct WindowHandle {
 }
 
 impl WindowHandle {
+    pub fn run_until_closed(self) {
+        run_thread_message_loop_until(|| !self.is_open()).unwrap();
+    }
+
     pub fn close(&self) {
         if let Some(hwnd) = self.hwnd.take() {
             unsafe {
@@ -86,7 +88,7 @@ pub struct BaseviewWindow {
     window_state: Rc<WindowState>,
     initial_size: Size,
 
-    handler_builder: Cell<Option<Box<HandlerBuilder>>>,
+    handler_builder: Cell<Option<WindowHandlerBuilder>>,
 
     // Things not directly used, but kept so their Drop impl runs when the window is destroyed
     _parent_handle: ParentHandle,
@@ -145,7 +147,7 @@ impl WindowImpl for BaseviewWindow {
 
         let handler = {
             let context = crate::WindowContext::new(Rc::clone(&self.window_state));
-            self.handler_builder.take().unwrap()(context)
+            self.handler_builder.take().unwrap().build(context)
         };
         let Ok(()) = window_state.handler.set(handler) else { unreachable!() };
 
@@ -406,34 +408,8 @@ unsafe fn wnd_proc_inner(
     }
 }
 
-pub struct Window;
-
-impl Window {
-    pub fn open_parented<H: WindowHandler>(
-        parent: &impl HasWindowHandle, options: WindowOpenOptions,
-        build: impl for<'a> FnOnce(crate::WindowContext) -> H + Send + 'static,
-    ) -> WindowHandle {
-        let parent = match parent.window_handle().unwrap().as_raw() {
-            RawWindowHandle::Win32(h) => h.hwnd,
-            h => panic!("unsupported parent handle {:?}", h),
-        };
-
-        Self::open(true, parent.get() as *mut _, options, build)
-    }
-
-    pub fn open_blocking<H: WindowHandler>(
-        options: WindowOpenOptions,
-        build: impl for<'a> FnOnce(crate::WindowContext) -> H + Send + 'static,
-    ) {
-        let window_handle = Self::open(false, null_mut(), options, build);
-
-        run_thread_message_loop_until(|| !window_handle.is_open()).unwrap();
-    }
-
-    fn open<H: WindowHandler>(
-        parented: bool, parent: HWND, options: WindowOpenOptions,
-        build: impl for<'a> FnOnce(crate::WindowContext) -> H + Send + 'static,
-    ) -> WindowHandle {
+impl WindowHandle {
+    pub fn create_window(options: WindowOpenOptions, build: WindowHandlerBuilder) -> WindowHandle {
         let extended_user_32 = ExtendedUser32::load().unwrap();
         let title = HSTRING::from(options.title);
 
@@ -444,7 +420,11 @@ impl Window {
 
         let window_size = options.size.to_physical(scaling_factor);
 
-        let style = if parented { WindowStyle::parented() } else { WindowStyle::embedded() };
+        let style = if options.parent.is_some() {
+            WindowStyle::parented()
+        } else {
+            WindowStyle::embedded()
+        };
         let dpi_ctx = DpiAwarenessContext::new(&extended_user_32).unwrap();
 
         let rect =
@@ -467,7 +447,7 @@ impl Window {
                 BaseviewWindow {
                     window_state,
                     initial_size: options.size,
-                    handler_builder: Cell::new(Some(Box::new(|w| Box::new(build(w))))),
+                    handler_builder: Cell::new(Some(build)),
 
                     _parent_handle: parent_handle,
                     _drop_target: None.into(),
@@ -479,9 +459,10 @@ impl Window {
             }
         };
 
+        let parent = options.parent.map(|p| p.handle);
+
         let hwnd =
-            create_window(&title, style, rect.size(), parent as *mut _, &dpi_ctx, initializer)
-                .unwrap();
+            create_window(&title, style, rect.size(), parent, &dpi_ctx, initializer).unwrap();
 
         // SAFETY: this handle should be safe to use
         let window = unsafe { HWnd::from_raw(hwnd) };

--- a/src/platform/win/window.rs
+++ b/src/platform/win/window.rs
@@ -82,8 +82,6 @@ impl Drop for ParentHandle {
     }
 }
 
-type HandlerBuilder = dyn FnOnce(crate::WindowContext) -> Box<dyn WindowHandler>;
-
 pub struct BaseviewWindow {
     window_state: Rc<WindowState>,
     initial_size: Size,

--- a/src/platform/win/window.rs
+++ b/src/platform/win/window.rs
@@ -30,8 +30,8 @@ use crate::wrappers::win32::{
     WindowStyle,
 };
 use crate::{
-    Event, MouseButton, MouseEvent, ScrollDelta, WindowEvent, WindowHandler, WindowOpenOptions,
-    WindowScalePolicy, WindowSize,
+    Event, MouseButton, MouseEvent, ScrollDelta, WindowEvent, WindowOpenOptions, WindowScalePolicy,
+    WindowSize,
 };
 
 #[allow(non_snake_case)]

--- a/src/platform/x11/event_loop.rs
+++ b/src/platform/x11/event_loop.rs
@@ -28,12 +28,12 @@ pub(crate) struct EventLoop {
 
 impl EventLoop {
     pub fn new(
-        window: Rc<WindowInner>, handler: impl WindowHandler, parent_handle: Option<ParentHandle>,
-        xkb_state: Option<XkbcommonState>,
+        window: Rc<WindowInner>, handler: Box<dyn WindowHandler>,
+        parent_handle: Option<ParentHandle>, xkb_state: Option<XkbcommonState>,
     ) -> Self {
         Self {
             window,
-            handler: Box::new(handler),
+            handler,
             parent_handle,
             frame_interval: Duration::from_millis(15),
             event_loop_running: false,

--- a/src/platform/x11/mod.rs
+++ b/src/platform/x11/mod.rs
@@ -1,6 +1,6 @@
 mod xcb_connection;
 
-use raw_window_handle::{DisplayHandle, XcbWindowHandle};
+use raw_window_handle::{DisplayHandle, HasWindowHandle, RawWindowHandle, XcbWindowHandle};
 use std::fmt::Formatter;
 use std::num::NonZero;
 use std::rc::Rc;
@@ -54,5 +54,21 @@ impl std::fmt::Debug for PlatformHandle {
             .field("connection", &display_string)
             .field("window_id", &self.window_id.get())
             .finish()
+    }
+}
+
+pub struct ParentWindowHandle {
+    window_id: u32,
+}
+
+impl ParentWindowHandle {
+    pub fn extract(window: &impl HasWindowHandle) -> Self {
+        let window_id = match window.window_handle().unwrap().as_raw() {
+            RawWindowHandle::Xlib(h) => h.window as u32,
+            RawWindowHandle::Xcb(h) => h.window.get(),
+            h => panic!("unsupported parent handle type {:?}", h),
+        };
+
+        Self { window_id }
     }
 }

--- a/src/platform/x11/mod.rs
+++ b/src/platform/x11/mod.rs
@@ -57,6 +57,7 @@ impl std::fmt::Debug for PlatformHandle {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct ParentWindowHandle {
     window_id: u32,
 }

--- a/src/platform/x11/window.rs
+++ b/src/platform/x11/window.rs
@@ -98,8 +98,8 @@ pub struct Window;
 type WindowOpenResult = Result<NonZero<x11rb::protocol::xproto::Window>, ()>;
 
 impl Window {
-    fn window_thread<H: WindowHandler>(
-        options: WindowOpenOptions, build: impl FnOnce(WindowContext) -> H + Send + 'static,
+    fn window_thread(
+        options: WindowOpenOptions, build: WindowHandlerBuilder,
         tx: mpsc::SyncSender<WindowOpenResult>, parent_handle: Option<ParentHandle>,
     ) -> Result<(), Box<dyn Error>> {
         // Connect to the X server
@@ -223,7 +223,7 @@ impl Window {
             gl_context,
         ));
 
-        let handler = build(WindowContext::new(Rc::clone(&inner)));
+        let handler = build.build(WindowContext::new(Rc::clone(&inner)));
 
         // Send an initial window resized event so the user is alerted of
         // the correct dpi scaling.

--- a/src/platform/x11/window.rs
+++ b/src/platform/x11/window.rs
@@ -18,7 +18,7 @@ use super::{event_loop::EventLoop, visual_info::WindowVisualConfig};
 use crate::context::WindowContext;
 use crate::handler::WindowHandlerBuilder;
 use crate::platform::x11::window_shared::WindowInner;
-use crate::{WindowHandler, WindowOpenOptions, WindowScalePolicy, WindowSize};
+use crate::{WindowOpenOptions, WindowScalePolicy, WindowSize};
 
 pub struct WindowHandle {
     window_id: Option<NonZero<x11rb::protocol::xproto::Window>>,

--- a/src/platform/x11/window.rs
+++ b/src/platform/x11/window.rs
@@ -1,4 +1,3 @@
-use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use std::cell::Cell;
 use std::error::Error;
 use std::num::NonZero;
@@ -17,6 +16,7 @@ use x11rb::wrapper::ConnectionExt as _;
 use super::X11Connection;
 use super::{event_loop::EventLoop, visual_info::WindowVisualConfig};
 use crate::context::WindowContext;
+use crate::handler::WindowHandlerBuilder;
 use crate::platform::x11::window_shared::WindowInner;
 use crate::{WindowHandler, WindowOpenOptions, WindowScalePolicy, WindowSize};
 
@@ -28,6 +28,29 @@ pub struct WindowHandle {
 }
 
 impl WindowHandle {
+    pub fn create_window(
+        options: WindowOpenOptions, handler: WindowHandlerBuilder,
+    ) -> WindowHandle {
+        let (tx, rx) = mpsc::sync_channel::<WindowOpenResult>(1);
+        let (parent_handle, mut window_handle) = ParentHandle::new();
+        let join_handle = thread::spawn(move || {
+            Window::window_thread(options, handler, tx.clone(), Some(parent_handle)).unwrap();
+        });
+
+        let raw_window_handle = rx.recv().unwrap().unwrap();
+        window_handle.window_id = Some(raw_window_handle);
+        window_handle.event_loop_handle = Some(join_handle).into();
+        window_handle
+    }
+
+    pub fn run_until_closed(self) {
+        let Some(thread) = self.event_loop_handle.take() else { return };
+
+        thread.join().unwrap_or_else(|err| {
+            eprintln!("Window thread panicked: {:#?}", err);
+        });
+    }
+
     pub fn close(&self) {
         self.close_requested.store(true, Ordering::Relaxed);
         if let Some(event_loop) = self.event_loop_handle.take() {
@@ -75,49 +98,8 @@ pub struct Window;
 type WindowOpenResult = Result<NonZero<x11rb::protocol::xproto::Window>, ()>;
 
 impl Window {
-    pub fn open_parented<H: WindowHandler>(
-        parent: &impl HasWindowHandle, options: WindowOpenOptions,
-        build: impl FnOnce(WindowContext) -> H + Send + 'static,
-    ) -> WindowHandle {
-        // Convert parent into something that X understands
-        let parent_id = match parent.window_handle().unwrap().as_raw() {
-            RawWindowHandle::Xlib(h) => h.window as u32,
-            RawWindowHandle::Xcb(h) => h.window.get(),
-            h => panic!("unsupported parent handle type {:?}", h),
-        };
-
-        let (tx, rx) = mpsc::sync_channel::<WindowOpenResult>(1);
-        let (parent_handle, mut window_handle) = ParentHandle::new();
-        let join_handle = thread::spawn(move || {
-            Self::window_thread(Some(parent_id), options, build, tx.clone(), Some(parent_handle))
-                .unwrap();
-        });
-
-        let raw_window_handle = rx.recv().unwrap().unwrap();
-        window_handle.window_id = Some(raw_window_handle);
-        window_handle.event_loop_handle = Some(join_handle).into();
-        window_handle
-    }
-
-    pub fn open_blocking<H: WindowHandler>(
-        options: WindowOpenOptions, build: impl FnOnce(WindowContext) -> H + Send + 'static,
-    ) {
-        let (tx, rx) = mpsc::sync_channel::<WindowOpenResult>(1);
-
-        let thread = thread::spawn(move || {
-            Self::window_thread(None, options, build, tx, None).unwrap();
-        });
-
-        let _ = rx.recv().unwrap().unwrap();
-
-        thread.join().unwrap_or_else(|err| {
-            eprintln!("Window thread panicked: {:#?}", err);
-        });
-    }
-
     fn window_thread<H: WindowHandler>(
-        parent: Option<u32>, options: WindowOpenOptions,
-        build: impl FnOnce(WindowContext) -> H + Send + 'static,
+        options: WindowOpenOptions, build: impl FnOnce(WindowContext) -> H + Send + 'static,
         tx: mpsc::SyncSender<WindowOpenResult>, parent_handle: Option<ParentHandle>,
     ) -> Result<(), Box<dyn Error>> {
         // Connect to the X server
@@ -129,7 +111,7 @@ impl Window {
 
         // Get screen information
         let screen = xcb_connection.screen();
-        let parent_id = parent.unwrap_or(screen.root);
+        let parent_id = options.parent.map(|p| p.window_id).unwrap_or(screen.root);
 
         let gc_id = xcb_connection.conn.generate_id()?;
         xcb_connection.conn.create_gc(

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,9 +1,7 @@
-use crate::context::WindowContext;
-use crate::handler::WindowHandler;
+use crate::handler::WindowHandlerBuilder;
 use crate::platform;
-use crate::window_open_options::WindowOpenOptions;
+use crate::*;
 use dpi::{LogicalSize, PhysicalSize, Pixel};
-use raw_window_handle::HasWindowHandle;
 use std::marker::PhantomData;
 
 pub struct WindowHandle {
@@ -15,6 +13,10 @@ pub struct WindowHandle {
 impl WindowHandle {
     fn new(window_handle: platform::WindowHandle) -> Self {
         Self { window_handle, phantom: PhantomData }
+    }
+
+    pub fn run_until_closed(self) {
+        self.window_handle.run_until_closed()
     }
 
     /// Close the window
@@ -29,24 +31,13 @@ impl WindowHandle {
     }
 }
 
-pub struct Window {
-    _private: (),
-}
-
-impl Window {
-    pub fn open_parented<H: WindowHandler>(
-        parent: &impl HasWindowHandle, options: WindowOpenOptions,
-        build: impl FnOnce(WindowContext) -> H + Send + 'static,
-    ) -> WindowHandle {
-        let window_handle = platform::Window::open_parented(parent, options, build);
-        WindowHandle::new(window_handle)
-    }
-
-    pub fn open_blocking<H: WindowHandler>(
-        options: WindowOpenOptions, build: impl FnOnce(WindowContext) -> H + Send + 'static,
-    ) {
-        platform::Window::open_blocking(options, build)
-    }
+pub fn create_window<H: WindowHandler>(
+    builder: WindowOpenOptions, handler: impl FnOnce(WindowContext) -> H + Send + 'static,
+) -> WindowHandle {
+    WindowHandle::new(platform::WindowHandle::create_window(
+        builder,
+        WindowHandlerBuilder::new(handler),
+    ))
 }
 
 /// A window's size, which can be read in either logical or physical pixels.

--- a/src/window_open_options.rs
+++ b/src/window_open_options.rs
@@ -1,8 +1,8 @@
-use dpi::{LogicalSize, Size};
-
 #[cfg(feature = "opengl")]
 use crate::gl::GlConfig;
 use crate::platform::ParentWindowHandle;
+use dpi::{LogicalSize, Size};
+use raw_window_handle::HasWindowHandle;
 
 /// The dpi scaling policy of the window
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
@@ -57,6 +57,12 @@ impl WindowOpenOptions {
     #[inline]
     pub fn with_scale_policy(mut self, scale: WindowScalePolicy) -> Self {
         self.scale = scale;
+        self
+    }
+
+    #[inline]
+    pub fn with_parent(mut self, parent: &impl HasWindowHandle) -> Self {
+        self.parent = Some(ParentWindowHandle::extract(parent));
         self
     }
 

--- a/src/window_open_options.rs
+++ b/src/window_open_options.rs
@@ -2,6 +2,7 @@ use dpi::{LogicalSize, Size};
 
 #[cfg(feature = "opengl")]
 use crate::gl::GlConfig;
+use crate::platform::ParentWindowHandle;
 
 /// The dpi scaling policy of the window
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
@@ -24,6 +25,8 @@ pub struct WindowOpenOptions {
 
     /// The dpi scaling policy
     pub scale: WindowScalePolicy,
+
+    pub(crate) parent: Option<ParentWindowHandle>,
 
     /// If provided, then an OpenGL context will be created for this window. You'll be able to
     /// access this context through [crate::WindowContext::gl_context].
@@ -71,6 +74,7 @@ impl Default for WindowOpenOptions {
             title: String::from("baseview window"),
             size: LogicalSize { width: 500.0, height: 400.0 }.into(),
             scale: WindowScalePolicy::default(),
+            parent: None,
             #[cfg(feature = "opengl")]
             gl_config: None,
         }

--- a/src/wrappers/win32/window.rs
+++ b/src/wrappers/win32/window.rs
@@ -51,7 +51,7 @@ pub trait WindowImpl: 'static {
 /// For any non-trivial operations (e.g. window resizing, GL context creation, etc.), put them in
 /// [`WindowImpl::after_create`] instead.
 pub fn create_window<W: WindowImpl>(
-    title: &HSTRING, style: WindowStyle, nc_size: PhysicalSize<u32>, parent: HWND,
+    title: &HSTRING, style: WindowStyle, nc_size: PhysicalSize<u32>, parent: Option<HWnd>,
     _dpi_ctx: &DpiAwarenessContext, initializer: impl FnOnce(HWnd) -> W + 'static,
 ) -> Result<HWND> {
     let instance = HInstance::get_from_dll();
@@ -69,7 +69,7 @@ pub fn create_window<W: WindowImpl>(
             0,
             nc_size.width.try_into().unwrap_or(i32::MAX),
             nc_size.height.try_into().unwrap_or(i32::MAX),
-            parent,
+            parent.map(|p| p.as_raw()).unwrap_or(null_mut()),
             null_mut(),
             instance.as_raw(),
             Rc::into_raw(data).cast(),

--- a/src/wrappers/win32/window/handle.rs
+++ b/src/wrappers/win32/window/handle.rs
@@ -23,7 +23,7 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
 /// a handle from this type might still return an "invalid handle" error).
 ///
 /// The role of this type is to help safely encapsulating most of the unsafe Win32 HWND APIs.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct HWnd(HWND);
 
 impl HWnd {


### PR DESCRIPTION
This PR removes the `Window::open_parented` and `Window::open_blocking` functions, in favor of a single `create_window` function.

Parenting is now done using the `with_parent` method in `WindowOpenOptions`.
To block the current thread until the window is closed (like `open_blocking`), use the new `run_until_closed()` method on the `WindowHandle` type, which consumes the window handle.

This makes parenting and blocking now two orthogonal features, allowing users to e.g. create a floating window that still doesn't block the current thread (or a parented window that does).