### PR TITLE
OpenGL: make `get_proc_address` take `&CStr` instead of `&str`

### DIFF
--- a/examples/render_femtovg/src/main.rs
+++ b/examples/render_femtovg/src/main.rs
@@ -6,6 +6,7 @@ use baseview::{
 use femtovg::renderer::OpenGl;
 use femtovg::{Canvas, Color};
 use std::cell::{Cell, RefCell};
+use std::ffi::CString;
 
 struct FemtovgExample {
     window_context: WindowContext,
@@ -20,8 +21,10 @@ impl FemtovgExample {
         let gl_context = window_context.gl_context().unwrap();
         unsafe { gl_context.make_current() };
 
-        let renderer =
-            unsafe { OpenGl::new_from_function(|s| gl_context.get_proc_address(s)) }.unwrap();
+        let renderer = unsafe {
+            OpenGl::new_from_function(|s| gl_context.get_proc_address(&CString::new(s).unwrap()))
+        }
+        .unwrap();
 
         let mut canvas = Canvas::new(renderer).unwrap();
         let size = window_context.size();

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -1,5 +1,5 @@
 use crate::platform::gl::*;
-use std::ffi::c_void;
+use std::ffi::{c_void, CStr};
 use std::marker::PhantomData;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -70,7 +70,7 @@ impl GlContext {
         self.inner.make_not_current();
     }
 
-    pub fn get_proc_address(&self, symbol: &str) -> *const c_void {
+    pub fn get_proc_address(&self, symbol: &CStr) -> *const c_void {
         self.inner.get_proc_address(symbol)
     }
 

--- a/src/platform/macos/gl.rs
+++ b/src/platform/macos/gl.rs
@@ -11,9 +11,9 @@ use objc2_app_kit::{
     NSOpenGLPixelFormat, NSOpenGLProfileVersion3_2Core, NSOpenGLProfileVersion4_1Core,
     NSOpenGLProfileVersionLegacy, NSOpenGLView, NSView,
 };
-use objc2_core_foundation::{CFBundle, CFString};
+use objc2_core_foundation::{CFBundle, CFString, CFStringBuiltInEncodings};
 use objc2_foundation::NSSize;
-use std::ffi::c_void;
+use std::ffi::{c_void, CStr};
 use std::ptr::NonNull;
 
 pub type CreationFailedError = ();
@@ -103,8 +103,19 @@ impl GlContext {
         NSOpenGLContext::clearCurrentContext();
     }
 
-    pub fn get_proc_address(&self, symbol: &str) -> *const c_void {
-        let symbol_name = CFString::from_str(symbol);
+    pub fn get_proc_address(&self, symbol: &CStr) -> *const c_void {
+        // SAFETY: The string pointer is valid
+        let symbol_name = unsafe {
+            CFString::with_bytes(
+                None,
+                symbol.as_ptr().cast(),
+                symbol.count_bytes().try_into().unwrap(),
+                CFStringBuiltInEncodings::EncodingUTF8.0,
+                false,
+            )
+        }
+        .unwrap();
+
         let framework_name = CFString::from_static_str("com.apple.opengl");
         let framework = CFBundle::bundle_with_identifier(Some(&framework_name)).unwrap();
 

--- a/src/platform/win/gl.rs
+++ b/src/platform/win/gl.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_void, CString, OsStr};
+use std::ffi::{c_void, CStr, CString, OsStr};
 use std::os::windows::ffi::OsStrExt;
 use std::rc::Rc;
 use windows_sys::{
@@ -307,8 +307,7 @@ impl GlContextInner {
         wglMakeCurrent(self.hdc, std::ptr::null_mut());
     }
 
-    pub fn get_proc_address(&self, symbol: &str) -> *const c_void {
-        let symbol = CString::new(symbol).unwrap();
+    pub fn get_proc_address(&self, symbol: &CStr) -> *const c_void {
         let symbol_ptr = symbol.as_ptr().cast();
 
         let addr = unsafe {

--- a/src/platform/win/gl.rs
+++ b/src/platform/win/gl.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_void, CStr, CString, OsStr};
+use std::ffi::{c_void, CStr, OsStr};
 use std::os::windows::ffi::OsStrExt;
 use std::rc::Rc;
 use windows_sys::{

--- a/src/platform/x11/gl.rs
+++ b/src/platform/x11/gl.rs
@@ -4,7 +4,7 @@ use crate::wrappers::glx::*;
 use crate::wrappers::xlib::{XErrorHandler, XLibError};
 
 use crate::platform::x11::xcb_window::XcbWindow;
-use std::ffi::{c_ulong, c_void, CString};
+use std::ffi::{c_ulong, c_void, CStr};
 use std::rc::Rc;
 use x11_dl::error::OpenError;
 use x11_dl::glx::GLXContext;
@@ -165,10 +165,8 @@ impl GlContextInner {
         self.window.get().into()
     }
 
-    pub fn get_proc_address(&self, symbol: &str) -> *const c_void {
-        let symbol = CString::new(symbol).unwrap();
-
-        match self.glx.get_proc_address(&symbol) {
+    pub fn get_proc_address(&self, symbol: &CStr) -> *const c_void {
+        match self.glx.get_proc_address(symbol) {
             Some(ptr) => ptr.as_ptr(),
             None => std::ptr::null(),
         }


### PR DESCRIPTION
This allows to reduce unneeded back-and-forth conversions.