### PR TITLE
Initial support for host callbacks

### DIFF
--- a/examples/plugin_clack/src/audio.rs
+++ b/examples/plugin_clack/src/audio.rs
@@ -3,7 +3,7 @@ use clack_plugin::prelude::*;
 
 pub struct ExamplePluginAudioProcessor;
 
-impl<'a> PluginAudioProcessor<'a, (), ExamplePluginMainThread> for ExamplePluginAudioProcessor {
+impl<'a> PluginAudioProcessor<'a, (), ExamplePluginMainThread<'a>> for ExamplePluginAudioProcessor {
     fn activate(
         _host: HostAudioProcessorHandle<'a>, _main_thread: &mut ExamplePluginMainThread,
         _shared: &'a (), _audio_config: PluginAudioConfiguration,

--- a/examples/plugin_clack/src/gui.rs
+++ b/examples/plugin_clack/src/gui.rs
@@ -14,7 +14,7 @@ use clack_plugin::prelude::{HostMainThreadHandle, HostSharedHandle};
 use raw_window_handle::HasRawWindowHandle;
 
 pub struct ExamplePluginGui {
-    handle: WindowHandle,
+    pub handle: WindowHandle,
 }
 
 impl PluginGuiImpl for ExamplePluginMainThread<'_> {
@@ -163,6 +163,7 @@ struct MainThreadHandler {
 
 impl HostMainThreadCaller for MainThreadHandler {
     fn call_main_thread(&mut self) {
+        eprintln!("Requesting main thread");
         self.host.request_callback();
     }
 }
@@ -174,6 +175,7 @@ struct HostGuiCallbacks {
 
 impl HostCallbacks for HostGuiCallbacks {
     fn resized(&mut self, new_size: WindowSize) -> Result<(), HandlerError> {
+        eprintln!("Resized: {:?}", new_size);
         let size = window_size_to_gui_size(new_size);
         self.ext.request_resize(&self.host, size.width, size.height)?;
         Ok(())

--- a/examples/plugin_clack/src/gui.rs
+++ b/examples/plugin_clack/src/gui.rs
@@ -174,8 +174,7 @@ struct HostGuiCallbacks {
 }
 
 impl HostCallbacks for HostGuiCallbacks {
-    fn resized(&mut self, new_size: WindowSize) -> Result<(), HandlerError> {
-        eprintln!("Resized: {:?}", new_size);
+    fn request_resize(&mut self, new_size: WindowSize) -> Result<(), HandlerError> {
         let size = window_size_to_gui_size(new_size);
         self.ext.request_resize(&self.host, size.width, size.height)?;
         Ok(())

--- a/examples/plugin_clack/src/gui.rs
+++ b/examples/plugin_clack/src/gui.rs
@@ -2,13 +2,14 @@ use crate::window_handler::OpenWindowExample;
 use crate::ExamplePluginMainThread;
 use baseview::dpi::*;
 use baseview::gl::GlConfig;
-use baseview::{WindowHandle, WindowOpenOptions, WindowSize};
+use baseview::host::{Host, HostCallbacks, HostMainThreadCaller};
+use baseview::{HandlerError, WindowHandle, WindowOpenOptions, WindowSize};
 use clack_extensions::gui::{
-    AspectRatioStrategy, GuiApiType, GuiConfiguration, GuiResizeHints, GuiSize, PluginGuiImpl,
-    Window as ClapWindow,
+    AspectRatioStrategy, GuiApiType, GuiConfiguration, GuiResizeHints, GuiSize, HostGui,
+    PluginGuiImpl, Window as ClapWindow,
 };
 use clack_plugin::plugin::PluginError;
-
+use clack_plugin::prelude::{HostMainThreadHandle, HostSharedHandle};
 #[allow(deprecated)]
 use raw_window_handle::HasRawWindowHandle;
 
@@ -16,7 +17,7 @@ pub struct ExamplePluginGui {
     handle: WindowHandle,
 }
 
-impl PluginGuiImpl for ExamplePluginMainThread {
+impl PluginGuiImpl for ExamplePluginMainThread<'_> {
     fn is_api_supported(&mut self, configuration: GuiConfiguration) -> bool {
         !configuration.is_floating
             && Some(configuration.api_type) == GuiApiType::default_for_current_platform()
@@ -97,7 +98,17 @@ impl PluginGuiImpl for ExamplePluginMainThread {
             .with_gl_config(GlConfig::default())
             .with_parent(&parent);
 
-        let window = baseview::create_window(options, OpenWindowExample::new)?;
+        let mut host = Host::new().with_main_thread(unsafe {
+            MainThreadHandler { host: self.host.shared().with_arbitrary_lifetime() }
+        });
+
+        if let Some(gui) = self.host_gui {
+            host = host.with_callbacks(unsafe {
+                HostGuiCallbacks { ext: gui, host: self.host.with_arbitrary_lifetime() }
+            });
+        }
+
+        let window = baseview::create_window_with_host(options, OpenWindowExample::new, host)?;
 
         self.gui = Some(ExamplePluginGui { handle: window });
 
@@ -143,5 +154,32 @@ fn gui_size_to_window_size(size: GuiSize) -> Size {
     #[cfg(not(target_os = "macos"))]
     {
         Size::Physical(PhysicalSize::new(size.width, size.height))
+    }
+}
+
+struct MainThreadHandler {
+    host: HostSharedHandle<'static>,
+}
+
+impl HostMainThreadCaller for MainThreadHandler {
+    fn call_main_thread(&mut self) {
+        self.host.request_callback();
+    }
+}
+
+struct HostGuiCallbacks {
+    ext: HostGui,
+    host: HostMainThreadHandle<'static>,
+}
+
+impl HostCallbacks for HostGuiCallbacks {
+    fn resized(&mut self, new_size: WindowSize) -> Result<(), HandlerError> {
+        let size = window_size_to_gui_size(new_size);
+        self.ext.request_resize(&self.host, size.width, size.height)?;
+        Ok(())
+    }
+
+    fn destroyed(&mut self) {
+        self.ext.closed(&self.host, true);
     }
 }

--- a/examples/plugin_clack/src/lib.rs
+++ b/examples/plugin_clack/src/lib.rs
@@ -52,7 +52,11 @@ pub struct ExamplePluginMainThread<'a> {
 }
 
 impl<'a> PluginMainThread<'a, ()> for ExamplePluginMainThread<'a> {
-    fn on_main_thread(&mut self) {}
+    fn on_main_thread(&mut self) {
+        if let Some(gui) = self.gui.as_mut() {
+            gui.handle.host_main_thread_callback();
+        }
+    }
 }
 
 clack_export_entry!(SinglePluginEntry<ExamplePlugin>);

--- a/examples/plugin_clack/src/lib.rs
+++ b/examples/plugin_clack/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::audio::ExamplePluginAudioProcessor;
 use crate::gui::ExamplePluginGui;
-use clack_extensions::gui::PluginGui;
+use clack_extensions::gui::{HostGui, PluginGui};
 use clack_plugin::prelude::*;
 
 mod audio;
@@ -15,7 +15,7 @@ pub struct ExamplePlugin;
 impl Plugin for ExamplePlugin {
     type AudioProcessor<'a> = ExamplePluginAudioProcessor;
     type Shared<'a> = ();
-    type MainThread<'a> = ExamplePluginMainThread;
+    type MainThread<'a> = ExamplePluginMainThread<'a>;
 
     fn declare_extensions(builder: &mut PluginExtensions<Self>, _shared: Option<&()>) {
         builder.register::<PluginGui>();
@@ -35,19 +35,23 @@ impl DefaultPluginFactory for ExamplePlugin {
     }
 
     fn new_main_thread<'a>(
-        _host: HostMainThreadHandle<'a>, _shared: &'a Self::Shared<'a>,
+        host: HostMainThreadHandle<'a>, _shared: &'a Self::Shared<'a>,
     ) -> Result<Self::MainThread<'a>, PluginError> {
-        Ok(Self::MainThread { gui: None })
+        Ok(Self::MainThread { gui: None, host_gui: host.get_extension(), host })
     }
 }
 
 /// The data that belongs to the main thread of our plugin.
-pub struct ExamplePluginMainThread {
+pub struct ExamplePluginMainThread<'a> {
+    /// The host handle
+    host: HostMainThreadHandle<'a>,
+    // The host GUI extension handle
+    host_gui: Option<HostGui>,
     /// The plugin's GUI state and context
     gui: Option<ExamplePluginGui>,
 }
 
-impl<'a> PluginMainThread<'a, ()> for ExamplePluginMainThread {
+impl<'a> PluginMainThread<'a, ()> for ExamplePluginMainThread<'a> {
     fn on_main_thread(&mut self) {}
 }
 

--- a/examples/plugin_clack/src/window_handler.rs
+++ b/examples/plugin_clack/src/window_handler.rs
@@ -1,6 +1,7 @@
 use baseview::dpi::PhysicalPosition;
 use baseview::{
-    Event, EventStatus, HandlerError, MouseEvent, WindowContext, WindowHandler, WindowSize,
+    Event, EventStatus, HandlerError, MouseButton, MouseEvent, WindowContext, WindowHandler,
+    WindowSize,
 };
 use std::cell::{Cell, RefCell};
 use std::num::NonZeroU32;
@@ -110,6 +111,16 @@ impl WindowHandler for OpenWindowExample {
             Event::Mouse(MouseEvent::CursorLeft) => {
                 self.is_cursor_inside.set(false);
                 self.damaged.set(true);
+            }
+            Event::Mouse(MouseEvent::ButtonPressed { button: MouseButton::Left, .. }) => {
+                let mut size = self.window_context.size().physical;
+                if self.mouse_pos.get().x < 100.0 {
+                    size.width -= 50;
+                } else {
+                    size.width += 50;
+                }
+
+                self.window_context.resize(size).unwrap();
             }
             _ => {}
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -50,7 +50,7 @@ impl WindowContext {
     /// The given `size` can either be in [physical](dpi::PhysicalSize) or
     /// [logical](dpi::LogicalSize) pixels.
     pub fn resize(&self, size: impl Into<Size>) -> Result<(), Error> {
-        self.inner.resize(size.into())?;
+        self.inner.resize_later(size.into())?;
         Ok(())
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -50,7 +50,7 @@ impl WindowContext {
     /// The given `size` can either be in [physical](dpi::PhysicalSize) or
     /// [logical](dpi::LogicalSize) pixels.
     pub fn resize(&self, size: impl Into<Size>) -> Result<(), Error> {
-        self.inner.resize_later(size.into())?;
+        self.inner.resize(size.into())?;
         Ok(())
     }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,15 +1,57 @@
 use crate::{HandlerError, WindowSize};
 use std::cell::RefCell;
 
+/// A special handler for the Window thread to wake up and call methods on the main thread.
+///
+/// [`WindowHandle::host_main_thread_callback`](crate::WindowHandle::host_main_thread_callback)
+/// should be called as a response to this.
+///
+/// # Platform compatibility notes
+///
+/// This is only needed on X11, as Windows and macOS windows already run on the main thread.
 pub trait HostMainThreadCaller: Send + 'static {
+    /// Schedules a callback on the main thread.
+    ///
+    /// [`WindowHandle::host_main_thread_callback`](crate::WindowHandle::host_main_thread_callback)
+    /// should be called as a response to this.
+    ///
+    /// # Platform compatibility notes
+    ///
+    /// Only X11 needs this. This can be implemented as a no-op on Windows and macOS.
     fn call_main_thread(&mut self);
 }
 
+/// A handler for baseview windows to interact with their host.
 pub trait HostCallbacks: 'static {
+    /// Requests the parent window to be resized to accommodate the child window with the given new
+    /// size.
+    ///
+    /// # Errors
+    ///
+    /// This can return any type of error, indicating the host either failed or denied to handle the
+    /// resize request.
+    /// If it does, the error is logged and the resize operation is canceled or reverted.
     fn request_resize(&mut self, new_size: WindowSize) -> Result<(), HandlerError>;
+    /// Notifies the host that the child window has been destroyed for a reason outside the host's
+    /// control.
+    ///
+    /// This can be because the display connection was lost, because the window handler crashed, or
+    /// because the window handler decided to close the window itself.
+    ///
+    /// The host should close its parent window, as it will not show anything useful anymore.
     fn destroyed(&mut self);
 }
 
+/// Configuration and callbacks for a window's host.
+///
+/// # Safety
+///
+/// This type and its methods are always safe to use.
+///
+/// It also brings the additional safety guarantee that all handlers given to this types will be
+/// destroyed alongside with the window, guaranteeing callbacks cannot be fired after the
+/// [`WindowHandle`](crate::WindowHandle) is dropped. (or after this [`Host`] object is dropped, if
+/// it never made it to a [`create_window_with_host`](crate::create_window_with_host) call).
 pub struct Host {
     #[cfg(target_os = "linux")]
     pub(crate) main_thread: Option<Box<dyn HostMainThreadCaller>>,
@@ -23,6 +65,10 @@ impl Default for Host {
 }
 
 impl Host {
+    /// Creates a new, empty host with no callbacks.
+    ///
+    /// Calling [`create_window_with_host`](crate::create_window_with_host) with this is equivalent
+    /// to just calling [`create_window`](crate::create_window).
     #[inline]
     pub fn new() -> Self {
         Self {
@@ -32,6 +78,13 @@ impl Host {
         }
     }
 
+    /// Sets the [`HostMainThreadCaller`] handler to be used.
+    ///
+    /// If another callback handler was already set, it is replaced.
+    ///
+    /// # Platform Compatibility notes
+    ///
+    /// This is only useful on X11. On Window and macOS, this is a no-op.
     #[inline]
     #[allow(unused)]
     pub fn with_main_thread(mut self, main_thread: impl HostMainThreadCaller) -> Self {
@@ -43,6 +96,9 @@ impl Host {
         self
     }
 
+    /// Sets the [`HostCallbacks`] handler to be used.
+    ///
+    /// If another callback handler was already set, it is replaced.
     #[inline]
     pub fn with_callbacks(mut self, callbacks: impl HostCallbacks) -> Self {
         self.callbacks = Some(RefCell::new(Box::new(callbacks)));

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,4 +1,5 @@
 use crate::{HandlerError, WindowSize};
+use std::cell::RefCell;
 
 pub trait HostMainThreadCaller: Send + 'static {
     fn call_main_thread(&mut self);
@@ -12,7 +13,7 @@ pub trait HostCallbacks: 'static {
 pub struct Host {
     #[cfg(target_os = "linux")]
     pub(crate) main_thread: Option<Box<dyn HostMainThreadCaller>>,
-    pub(crate) callbacks: Option<Box<dyn HostCallbacks>>,
+    pub(crate) callbacks: Option<RefCell<Box<dyn HostCallbacks>>>,
 }
 
 impl Default for Host {
@@ -44,7 +45,22 @@ impl Host {
 
     #[inline]
     pub fn with_callbacks(mut self, callbacks: impl HostCallbacks) -> Self {
-        self.callbacks = Some(Box::new(callbacks));
+        self.callbacks = Some(RefCell::new(Box::new(callbacks)));
         self
+    }
+}
+
+#[allow(unused)]
+impl Host {
+    pub(crate) fn notify_destroyed(&self) {
+        let Some(callbacks) = &self.callbacks else { return };
+        let Ok(mut callbacks) = callbacks.try_borrow_mut() else { return };
+        callbacks.destroyed();
+    }
+
+    pub(crate) fn request_resize(&self, new_size: WindowSize) -> Result<(), HandlerError> {
+        let Some(callbacks) = &self.callbacks else { return Ok(()) };
+        let Ok(mut callbacks) = callbacks.try_borrow_mut() else { return Ok(()) };
+        callbacks.request_resize(new_size)
     }
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -32,6 +32,7 @@ impl Host {
     }
 
     #[inline]
+    #[allow(unused)]
     pub fn with_main_thread(mut self, main_thread: impl HostMainThreadCaller) -> Self {
         #[cfg(target_os = "linux")]
         {

--- a/src/host.rs
+++ b/src/host.rs
@@ -10,6 +10,7 @@ pub trait HostCallbacks: 'static {
 }
 
 pub struct Host {
+    #[cfg(target_os = "linux")]
     pub(crate) main_thread: Option<Box<dyn HostMainThreadCaller>>,
     pub(crate) callbacks: Option<Box<dyn HostCallbacks>>,
 }
@@ -21,15 +22,26 @@ impl Default for Host {
 }
 
 impl Host {
+    #[inline]
     pub fn new() -> Self {
-        Self { main_thread: None, callbacks: None }
+        Self {
+            #[cfg(target_os = "linux")]
+            main_thread: None,
+            callbacks: None,
+        }
     }
 
+    #[inline]
     pub fn with_main_thread(mut self, main_thread: impl HostMainThreadCaller) -> Self {
-        self.main_thread = Some(Box::new(main_thread));
+        #[cfg(target_os = "linux")]
+        {
+            self.main_thread = Some(Box::new(main_thread));
+        }
+
         self
     }
 
+    #[inline]
     pub fn with_callbacks(mut self, callbacks: impl HostCallbacks) -> Self {
         self.callbacks = Some(Box::new(callbacks));
         self

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,0 +1,37 @@
+use crate::{HandlerError, WindowSize};
+
+pub trait HostMainThreadCaller: Send + 'static {
+    fn call_main_thread(&mut self);
+}
+
+pub trait HostCallbacks: 'static {
+    fn resized(&mut self, new_size: WindowSize) -> Result<(), HandlerError>;
+    fn destroyed(&mut self);
+}
+
+pub struct Host {
+    pub(crate) main_thread: Option<Box<dyn HostMainThreadCaller>>,
+    pub(crate) callbacks: Option<Box<dyn HostCallbacks>>,
+}
+
+impl Default for Host {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Host {
+    pub fn new() -> Self {
+        Self { main_thread: None, callbacks: None }
+    }
+
+    pub fn with_main_thread(mut self, main_thread: impl HostMainThreadCaller) -> Self {
+        self.main_thread = Some(Box::new(main_thread));
+        self
+    }
+
+    pub fn with_callbacks(mut self, callbacks: impl HostCallbacks) -> Self {
+        self.callbacks = Some(Box::new(callbacks));
+        self
+    }
+}

--- a/src/host.rs
+++ b/src/host.rs
@@ -5,7 +5,7 @@ pub trait HostMainThreadCaller: Send + 'static {
 }
 
 pub trait HostCallbacks: 'static {
-    fn resized(&mut self, new_size: WindowSize) -> Result<(), HandlerError>;
+    fn request_resize(&mut self, new_size: WindowSize) -> Result<(), HandlerError>;
     fn destroyed(&mut self);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod context;
 mod error;
 mod event;
 mod handler;
+pub mod host;
 mod keyboard;
 mod mouse_cursor;
 mod tracing;

--- a/src/platform/macos/context.rs
+++ b/src/platform/macos/context.rs
@@ -31,7 +31,7 @@ impl WindowContext {
     pub fn request_close(&self) {
         let Some(view) = self.view.load() else { return };
         let Some(view) = view.inner_ref() else { return };
-        BaseviewView::close(view);
+        BaseviewView::close(view, false);
     }
 
     pub fn has_focus(&self) -> bool {

--- a/src/platform/macos/context.rs
+++ b/src/platform/macos/context.rs
@@ -67,7 +67,7 @@ impl WindowContext {
             return Ok(());
         }
 
-        BaseviewView::resize(view, size);
+        BaseviewView::resize(view, size, true);
 
         Ok(())
     }

--- a/src/platform/macos/view.rs
+++ b/src/platform/macos/view.rs
@@ -3,6 +3,7 @@
 use super::keyboard::{make_modifiers, KeyboardState};
 use super::window::WindowSharedState;
 use crate::handler::WindowHandlerBuilder;
+use crate::host::{Host, HostCallbacks};
 use crate::platform::*;
 use crate::tracing::warn;
 use crate::wrappers::appkit::*;
@@ -22,6 +23,7 @@ use objc2_app_kit::{
 };
 use objc2_foundation::{NSArray, NSNotification, NSPoint, NSRect, NSSize, NSString};
 use std::cell::{Cell, RefCell};
+use std::ops::DerefMut;
 use std::rc::Rc;
 
 pub enum ViewParentingType {
@@ -41,6 +43,8 @@ pub(crate) struct BaseviewView {
 
     parenting: ViewParentingType,
 
+    host: RefCell<Host>,
+
     #[cfg(feature = "opengl")]
     pub(crate) gl_context: std::cell::OnceCell<super::gl::GlContext>,
 }
@@ -48,7 +52,7 @@ pub(crate) struct BaseviewView {
 impl BaseviewView {
     pub fn new(
         _options: WindowOpenOptions, builder: WindowHandlerBuilder, parenting: ViewParentingType,
-        final_size: LogicalSize<f64>, mtm: MainThreadMarker,
+        host: Host, final_size: LogicalSize<f64>, mtm: MainThreadMarker,
     ) -> Result<(Retained<View<Self>>, Rc<WindowSharedState>)> {
         let view_rect =
             NSRect::new(NSPoint::ZERO, NSSize::new(final_size.width, final_size.height));
@@ -64,6 +68,7 @@ impl BaseviewView {
             window_handler: WindowHandlerContainer::new(),
             notification_center_observer: None.into(),
             parenting,
+            host: host.into(),
 
             #[cfg(feature = "opengl")]
             gl_context: std::cell::OnceCell::new(),
@@ -188,6 +193,18 @@ impl BaseviewView {
             Self::close(this);
         }
     }
+
+    fn use_host_callback<E>(
+        this: ViewRef<Self>,
+        handle: impl FnOnce(&mut dyn HostCallbacks) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), E> {
+        let Ok(mut host) = this.host.try_borrow_mut() else {
+            return Ok(());
+        };
+
+        let Some(callback) = host.callbacks.as_mut() else { return Ok(()) };
+        handle(callback.deref_mut())
+    }
 }
 
 impl Drop for BaseviewView {
@@ -232,15 +249,20 @@ impl ViewImpl for BaseviewView {
         {
             let previous = this.state.size.replace(current_size);
             this.state.scale_factor.set(current_scale_factor);
+            let new_size = WindowSize::from_logical(current_size, current_scale_factor);
 
-            let result = this.window_handler.use_handler(|h| {
-                h.resized(WindowSize::from_logical(current_size, current_scale_factor))
-            });
+            let result = this.window_handler.use_handler(|h| h.resized(new_size));
 
             if let Some(Err(e)) = result {
                 warn!("Window Handler failed to resize: {}", e);
                 this.state.size.set(previous);
                 Self::resize(this, previous.into())
+            }
+
+            // TODO: only if not coming from host
+            if let Err(e) = Self::use_host_callback(this, |c| c.request_resize(new_size)) {
+                warn!("Host failed to resize parent view: {}", e);
+                Self::resize(this, previous.into()) // TODO: break error loop?
             }
         }
     }

--- a/src/platform/macos/view.rs
+++ b/src/platform/macos/view.rs
@@ -43,7 +43,7 @@ pub(crate) struct BaseviewView {
 
     parenting: ViewParentingType,
 
-    host: RefCell<Host>,
+    host: Host,
 
     #[cfg(feature = "opengl")]
     pub(crate) gl_context: std::cell::OnceCell<super::gl::GlContext>,
@@ -136,7 +136,7 @@ impl BaseviewView {
         Ok((view, state))
     }
 
-    pub fn close(this: ViewRef<Self>) {
+    pub fn close(this: ViewRef<Self>, from_host: bool) {
         this.state.closed.set(true);
         this.view.removeFromSuperview();
         this.notification_center_observer.take();
@@ -153,6 +153,10 @@ impl BaseviewView {
             if let Some(app) = running_app.load() {
                 app.stop(Some(&app));
             }
+        }
+
+        if !from_host {
+            this.host.notify_destroyed();
         }
     }
 
@@ -190,20 +194,8 @@ impl BaseviewView {
     fn trigger_frame(this: ViewRef<Self>) {
         if let Some(Err(e)) = this.window_handler.use_handler(|h| h.on_frame()) {
             warn!("Error while rendering frame: {}", e);
-            Self::close(this);
+            Self::close(this, false);
         }
-    }
-
-    fn use_host_callback<E>(
-        this: ViewRef<Self>,
-        handle: impl FnOnce(&mut dyn HostCallbacks) -> core::result::Result<(), E>,
-    ) -> core::result::Result<(), E> {
-        let Ok(mut host) = this.host.try_borrow_mut() else {
-            return Ok(());
-        };
-
-        let Some(callback) = host.callbacks.as_mut() else { return Ok(()) };
-        handle(callback.deref_mut())
     }
 }
 
@@ -233,7 +225,7 @@ impl ViewImpl for BaseviewView {
 
     fn window_should_close(this: ViewRef<Self>) -> bool {
         Self::trigger_event(this, Event::Window(WindowEvent::WillClose));
-        Self::close(this);
+        Self::close(this, false);
 
         true
     }
@@ -260,7 +252,7 @@ impl ViewImpl for BaseviewView {
             }
 
             // TODO: only if not coming from host
-            if let Err(e) = Self::use_host_callback(this, |c| c.request_resize(new_size)) {
+            if let Err(e) = this.host.request_resize(new_size) {
                 warn!("Host failed to resize parent view: {}", e);
                 Self::resize(this, previous.into()) // TODO: break error loop?
             }

--- a/src/platform/macos/view.rs
+++ b/src/platform/macos/view.rs
@@ -3,7 +3,7 @@
 use super::keyboard::{make_modifiers, KeyboardState};
 use super::window::WindowSharedState;
 use crate::handler::WindowHandlerBuilder;
-use crate::host::{Host, HostCallbacks};
+use crate::host::Host;
 use crate::platform::*;
 use crate::tracing::warn;
 use crate::wrappers::appkit::*;
@@ -23,7 +23,6 @@ use objc2_app_kit::{
 };
 use objc2_foundation::{NSArray, NSNotification, NSPoint, NSRect, NSSize, NSString};
 use std::cell::{Cell, RefCell};
-use std::ops::DerefMut;
 use std::rc::Rc;
 
 pub enum ViewParentingType {

--- a/src/platform/macos/view.rs
+++ b/src/platform/macos/view.rs
@@ -67,7 +67,7 @@ impl BaseviewView {
             window_handler: WindowHandlerContainer::new(),
             notification_center_observer: None.into(),
             parenting,
-            host: host.into(),
+            host,
 
             #[cfg(feature = "opengl")]
             gl_context: std::cell::OnceCell::new(),

--- a/src/platform/macos/view.rs
+++ b/src/platform/macos/view.rs
@@ -159,7 +159,7 @@ impl BaseviewView {
         }
     }
 
-    pub fn resize(this: ViewRef<Self>, size: Size) {
+    pub fn resize(this: ViewRef<Self>, size: Size, notify_host: bool) {
         let size = size.to_logical::<f64>(this.view.backing_scale_factor());
         // NOTE: macOS gives you a personal rave if you pass in fractional pixels here. Even
         // though the size is in fractional pixels.
@@ -182,7 +182,7 @@ impl BaseviewView {
             }
         }
 
-        Self::view_did_change_backing_properties(this);
+        Self::view_did_change_backing_properties(this, notify_host);
     }
 
     /// Trigger the event immediately and return the event status.
@@ -229,7 +229,7 @@ impl ViewImpl for BaseviewView {
         true
     }
 
-    fn view_did_change_backing_properties(this: ViewRef<Self>) {
+    fn view_did_change_backing_properties(this: ViewRef<Self>, notify_host: bool) {
         let current_size = this.view.size();
         let current_scale_factor = this.view.backing_scale_factor();
 
@@ -247,13 +247,17 @@ impl ViewImpl for BaseviewView {
             if let Some(Err(e)) = result {
                 warn!("Window Handler failed to resize: {}", e);
                 this.state.size.set(previous);
-                Self::resize(this, previous.into())
+
+                Self::resize(this, previous.into(), false);
+                return;
             }
 
-            // TODO: only if not coming from host
-            if let Err(e) = this.host.request_resize(new_size) {
-                warn!("Host failed to resize parent view: {}", e);
-                Self::resize(this, previous.into()) // TODO: break error loop?
+            if notify_host {
+                if let Err(e) = this.host.request_resize(new_size) {
+                    warn!("Host failed to resize parent view: {}", e);
+
+                    Self::resize(this, previous.into(), false);
+                }
             }
         }
     }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -108,7 +108,7 @@ impl WindowHandle {
         let Some(view) = self.view.load() else { return Ok(()) };
         let Some(view) = view.inner_ref() else { return Ok(()) };
 
-        BaseviewView::resize(view, size);
+        BaseviewView::resize(view, size, false);
 
         Ok(())
     }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -7,6 +7,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use crate::handler::WindowHandlerBuilder;
+use crate::host::Host;
 use crate::platform::macos::view::{BaseviewView, ViewParentingType};
 use crate::platform::Result;
 use crate::wrappers::appkit::{create_window, View};
@@ -30,7 +31,7 @@ impl Drop for WindowHandle {
 
 impl WindowHandle {
     pub fn create_window(
-        mut options: WindowOpenOptions, handler: WindowHandlerBuilder,
+        mut options: WindowOpenOptions, handler: WindowHandlerBuilder, host: Host,
     ) -> Result<Self> {
         autoreleasepool(|_| {
             let Some(mtm) = MainThreadMarker::new() else {
@@ -41,16 +42,16 @@ impl WindowHandle {
             let _ = NSApplication::sharedApplication(mtm);
 
             if let Some(parent) = options.parent.take() {
-                return Self::create_window_parented(options, handler, parent.view, mtm);
+                return Self::create_window_parented(options, handler, host, parent.view, mtm);
             }
 
-            Self::create_window_standalone(options, handler, mtm)
+            Self::create_window_standalone(options, handler, host, mtm)
         })
     }
 
     pub fn create_window_parented(
-        builder: WindowOpenOptions, handler: WindowHandlerBuilder, parent_view: Retained<NSView>,
-        mtm: MainThreadMarker,
+        builder: WindowOpenOptions, handler: WindowHandlerBuilder, host: Host,
+        parent_view: Retained<NSView>, mtm: MainThreadMarker,
     ) -> Result<Self> {
         let parenting =
             ViewParentingType::Parented { parent_view: Weak::from_retained(&parent_view) };
@@ -59,13 +60,15 @@ impl WindowHandle {
             parent_view.window().map(|w| w.backingScaleFactor()).unwrap_or(1.0);
         let final_size = builder.size.to_logical(backing_scale_factor);
 
-        let (ns_view, state) = BaseviewView::new(builder, handler, parenting, final_size, mtm)?;
+        let (ns_view, state) =
+            BaseviewView::new(builder, handler, parenting, host, final_size, mtm)?;
 
         Ok(Self { mtm, state, _window: None, view: Weak::from_retained(&ns_view) })
     }
 
     pub fn create_window_standalone(
-        builder: WindowOpenOptions, handler: WindowHandlerBuilder, mtm: MainThreadMarker,
+        builder: WindowOpenOptions, handler: WindowHandlerBuilder, host: Host,
+        mtm: MainThreadMarker,
     ) -> Result<Self> {
         let app = NSApplication::sharedApplication(mtm);
         let window = create_window_with_options(&builder, mtm);
@@ -78,7 +81,7 @@ impl WindowHandle {
             owned_window: Weak::from_retained(&window),
         };
 
-        let (view, state) = BaseviewView::new(builder, handler, parenting, final_size, mtm)?;
+        let (view, state) = BaseviewView::new(builder, handler, parenting, host, final_size, mtm)?;
 
         Ok(Self { mtm, state, view: Weak::from_retained(&view), _window: Some(window) })
     }
@@ -90,6 +93,11 @@ impl WindowHandle {
 
     pub fn is_open(&self) -> bool {
         self.state.closed.get()
+    }
+
+    #[inline]
+    pub fn handle_main_thread_callback(&self) {
+        // No-op
     }
 
     pub fn size(&self) -> WindowSize {

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -25,7 +25,7 @@ impl Drop for WindowHandle {
         let Some(view) = self.view.load() else { return };
         let Some(view) = view.inner_ref() else { return };
 
-        BaseviewView::close(view);
+        BaseviewView::close(view, true);
     }
 }
 

--- a/src/platform/win/window.rs
+++ b/src/platform/win/window.rs
@@ -15,7 +15,7 @@ use windows_sys::Win32::{
 
 use crate::{warn, HandlerError};
 use dpi::{PhysicalPosition, PhysicalSize, Size};
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::num::NonZeroUsize;
 
 pub(crate) const BV_WINDOW_MUST_CLOSE: u32 = WM_USER + 1;

--- a/src/platform/win/window.rs
+++ b/src/platform/win/window.rs
@@ -560,7 +560,7 @@ impl WindowHandle {
                     initial_size: options.size,
                     handler_builder: Cell::new(Some(build)),
                     shared_state,
-                    host: host.into(),
+                    host,
 
                     _drop_target: None.into(),
                     _keyboard_hook: None.into(),

--- a/src/platform/win/window.rs
+++ b/src/platform/win/window.rs
@@ -23,6 +23,7 @@ pub(crate) const BV_WINDOW_MUST_CLOSE: u32 = WM_USER + 1;
 use super::drop_target::DropTarget;
 use super::*;
 use crate::handler::WindowHandlerBuilder;
+use crate::host::Host;
 use crate::platform::win::window_state::{WindowSharedState, WindowState};
 use crate::platform::Error;
 use crate::wrappers::win32::cursor::SystemCursor;
@@ -112,6 +113,11 @@ impl WindowHandle {
             Err(Error::ResizeFailed)
         }
     }
+
+    #[inline]
+    pub fn handle_main_thread_callback(&self) {
+        // No-op
+    }
 }
 
 impl Drop for WindowHandle {
@@ -128,6 +134,7 @@ pub struct BaseviewWindow {
     initial_size: Size,
 
     handler_builder: Cell<Option<WindowHandlerBuilder>>,
+    host: Host,
 
     // Things not directly used, but kept so their Drop impl runs when the window is destroyed
     _keyboard_hook: Cell<Option<hook::KeyboardHookHandle>>,
@@ -198,7 +205,7 @@ impl WindowImpl for BaseviewWindow {
     unsafe fn handle_message(
         &self, window: HWnd, msg: u32, wparam: WPARAM, lparam: LPARAM,
     ) -> Option<LRESULT> {
-        unsafe { wnd_proc_inner(window, msg, wparam, lparam, &self.window_state) }
+        unsafe { wnd_proc_inner(window, msg, wparam, lparam, &self) }
     }
 
     fn before_destroy(&self, window: HWnd) {
@@ -209,8 +216,9 @@ impl WindowImpl for BaseviewWindow {
 /// Our custom `wnd_proc` handler. If the result contains a value, then this is returned after
 /// handling any deferred tasks. otherwise the default window procedure is invoked.
 unsafe fn wnd_proc_inner(
-    window: HWnd, msg: u32, wparam: WPARAM, lparam: LPARAM, window_state: &WindowState,
+    window: HWnd, msg: u32, wparam: WPARAM, lparam: LPARAM, window_bv: &BaseviewWindow,
 ) -> Option<LRESULT> {
+    let window_state = &window_bv.window_state;
     match msg {
         WM_MOUSEMOVE => {
             if window_state.mouse_was_outside_window.get() {
@@ -465,7 +473,7 @@ unsafe fn wnd_proc_inner(
 
 impl WindowHandle {
     pub fn create_window(
-        options: WindowOpenOptions, build: WindowHandlerBuilder,
+        options: WindowOpenOptions, build: WindowHandlerBuilder, host: Host,
     ) -> Result<WindowHandle> {
         let extended_user_32 = ExtendedUser32::load()?;
         let title = HSTRING::from(options.title);
@@ -495,6 +503,7 @@ impl WindowHandle {
                     initial_size: options.size,
                     handler_builder: Cell::new(Some(build)),
                     shared_state,
+                    host,
 
                     _drop_target: None.into(),
                     _keyboard_hook: None.into(),

--- a/src/platform/win/window.rs
+++ b/src/platform/win/window.rs
@@ -13,9 +13,9 @@ use windows_sys::Win32::{
     },
 };
 
-use crate::warn;
+use crate::{warn, HandlerError};
 use dpi::{PhysicalPosition, PhysicalSize, Size};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::num::NonZeroUsize;
 
 pub(crate) const BV_WINDOW_MUST_CLOSE: u32 = WM_USER + 1;
@@ -73,6 +73,7 @@ impl WindowHandle {
     pub fn resize(&self, new_size: Size) -> Result<()> {
         let Some(hwnd) = self.hwnd.get() else { return Ok(()) };
         let new_size = new_size.to_physical(self.state.scale_factor());
+        let _guard = self.state.originate_host_resize();
         hwnd.resize_and_activate(new_size, self.state.current_dpi.get(), &self.state.user32)?;
 
         if self.state.current_size.get() == new_size {
@@ -105,6 +106,8 @@ impl WindowHandle {
             return Ok(());
         }
 
+        let _guard = self.state.originate_host_resize();
+
         hwnd.resize_and_activate(new_size, None, &self.state.user32)?;
 
         if self.state.current_size.get() == new_size {
@@ -123,7 +126,10 @@ impl WindowHandle {
 impl Drop for WindowHandle {
     fn drop(&mut self) {
         if let Some(hwnd) = self.hwnd.take() {
-            let _ = hwnd.destroy();
+            let _guard = self.state.originate_host_destroy();
+            if let Err(e) = hwnd.destroy() {
+                warn!("Failed to destroy window: {}", e);
+            }
         }
     }
 }
@@ -134,7 +140,7 @@ pub struct BaseviewWindow {
     initial_size: Size,
 
     handler_builder: Cell<Option<WindowHandlerBuilder>>,
-    host: Host,
+    host: RefCell<Host>,
 
     // Things not directly used, but kept so their Drop impl runs when the window is destroyed
     _keyboard_hook: Cell<Option<hook::KeyboardHookHandle>>,
@@ -144,9 +150,35 @@ pub struct BaseviewWindow {
     pub gl_config: Option<crate::gl::GlConfig>,
 }
 
+impl BaseviewWindow {
+    fn notify_destroyed_to_host(&self) {
+        if self.shared_state.destroy_host_originated.get() {
+            return;
+        };
+
+        let Ok(mut host) = self.host.try_borrow_mut() else { return };
+        let Some(host) = &mut host.callbacks else { return };
+
+        host.destroyed()
+    }
+
+    fn request_resize_from_host(
+        &self, new_size: WindowSize,
+    ) -> core::result::Result<(), HandlerError> {
+        if self.shared_state.resize_host_originated.get() {
+            return Ok(());
+        };
+
+        let Ok(mut host) = self.host.try_borrow_mut() else { return Ok(()) };
+        let Some(host) = &mut host.callbacks else { return Ok(()) };
+        host.request_resize(new_size)
+    }
+}
+
 impl Drop for BaseviewWindow {
     fn drop(&mut self) {
         self.shared_state.is_alive.set(false);
+        self.notify_destroyed_to_host();
     }
 }
 
@@ -406,6 +438,21 @@ unsafe fn wnd_proc_inner(
                 return Some(-1);
             }
 
+            if let Err(e) = window_bv.request_resize_from_host(new_size) {
+                warn!("Resize request from Host failed: {}. Reverting to previous size.", e);
+
+                if let Err(e) = handler.resized(new_size) {
+                    warn!("Window Handler failed to resize to previous window size: {}", e);
+                }
+
+                window_state.shared.current_size.set(previous);
+                if let Err(e) = window_state.resize(previous.into()) {
+                    warn!("Failed to resize back to previous window size: {}", e);
+                }
+
+                return Some(-1);
+            }
+
             None
         }
         WM_DPICHANGED => {
@@ -440,6 +487,21 @@ unsafe fn wnd_proc_inner(
                     if let Err(e) = window_state.resize(previous_size.into()) {
                         warn!("Failed to resize back to previous window size: {}", e);
                     }
+                }
+
+                if let Err(e) = window_bv.request_resize_from_host(new_size) {
+                    warn!("Resize request from Host failed: {}. Reverting to previous size.", e);
+
+                    if let Err(e) = handler.resized(new_size) {
+                        warn!("Window Handler failed to resize to previous window size: {}", e);
+                    }
+
+                    window_state.shared.current_size.set(previous_size);
+                    if let Err(e) = window_state.resize(previous_size.into()) {
+                        warn!("Failed to resize back to previous window size: {}", e);
+                    }
+
+                    return Some(-1);
                 }
             }
 
@@ -503,7 +565,7 @@ impl WindowHandle {
                     initial_size: options.size,
                     handler_builder: Cell::new(Some(build)),
                     shared_state,
-                    host,
+                    host: host.into(),
 
                     _drop_target: None.into(),
                     _keyboard_hook: None.into(),

--- a/src/platform/win/window.rs
+++ b/src/platform/win/window.rs
@@ -140,7 +140,7 @@ pub struct BaseviewWindow {
     initial_size: Size,
 
     handler_builder: Cell<Option<WindowHandlerBuilder>>,
-    host: RefCell<Host>,
+    host: Host,
 
     // Things not directly used, but kept so their Drop impl runs when the window is destroyed
     _keyboard_hook: Cell<Option<hook::KeyboardHookHandle>>,
@@ -156,10 +156,7 @@ impl BaseviewWindow {
             return;
         };
 
-        let Ok(mut host) = self.host.try_borrow_mut() else { return };
-        let Some(host) = &mut host.callbacks else { return };
-
-        host.destroyed()
+        self.host.notify_destroyed()
     }
 
     fn request_resize_from_host(
@@ -169,9 +166,7 @@ impl BaseviewWindow {
             return Ok(());
         };
 
-        let Ok(mut host) = self.host.try_borrow_mut() else { return Ok(()) };
-        let Some(host) = &mut host.callbacks else { return Ok(()) };
-        host.request_resize(new_size)
+        self.host.request_resize(new_size)
     }
 }
 

--- a/src/platform/win/window.rs
+++ b/src/platform/win/window.rs
@@ -205,7 +205,7 @@ impl WindowImpl for BaseviewWindow {
     unsafe fn handle_message(
         &self, window: HWnd, msg: u32, wparam: WPARAM, lparam: LPARAM,
     ) -> Option<LRESULT> {
-        unsafe { wnd_proc_inner(window, msg, wparam, lparam, &self) }
+        unsafe { wnd_proc_inner(window, msg, wparam, lparam, self) }
     }
 
     fn before_destroy(&self, window: HWnd) {

--- a/src/platform/win/window_state.rs
+++ b/src/platform/win/window_state.rs
@@ -146,6 +146,8 @@ pub struct WindowSharedState {
     pub current_size: Cell<PhysicalSize<u32>>,
     pub current_dpi: Cell<Option<Dpi>>, // None if Win32 HiDPI isn't supported
     pub fallback_scale_factor: Cell<Option<f64>>,
+    pub resize_host_originated: Cell<bool>,
+    pub destroy_host_originated: Cell<bool>,
 
     pub user32: ExtendedUser32,
 }
@@ -157,6 +159,8 @@ impl WindowSharedState {
             current_dpi: None.into(),
             current_size: current_size.into(),
             fallback_scale_factor: None.into(),
+            resize_host_originated: false.into(),
+            destroy_host_originated: false.into(),
             user32,
         }
         .into()
@@ -172,5 +176,22 @@ impl WindowSharedState {
         } else {
             self.fallback_scale_factor.get().unwrap_or(1.0)
         }
+    }
+
+    pub fn originate_host_resize(&self) -> impl Drop + use<'_> {
+        self.resize_host_originated.set(true);
+        Guard(&self.resize_host_originated)
+    }
+
+    pub fn originate_host_destroy(&self) -> impl Drop + use<'_> {
+        self.destroy_host_originated.set(true);
+        Guard(&self.destroy_host_originated)
+    }
+}
+
+struct Guard<'a>(&'a Cell<bool>);
+impl<'a> Drop for Guard<'a> {
+    fn drop(&mut self) {
+        self.0.set(false);
     }
 }

--- a/src/platform/x11/error.rs
+++ b/src/platform/x11/error.rs
@@ -16,7 +16,6 @@ use x11rb::x11_utils::{TryParse, X11Error};
 pub enum FatalError {
     Connection(ConnectionError),
     SendMainThread,
-    ReceiveMainThread,
 }
 
 impl Display for FatalError {
@@ -25,7 +24,6 @@ impl Display for FatalError {
             FatalError::Connection(e) => e.fmt(f),
             // TODO: better errors
             FatalError::SendMainThread => f.write_str("SendMainThread"),
-            FatalError::ReceiveMainThread => f.write_str("ReceiveMainThread"),
         }
     }
 }

--- a/src/platform/x11/error.rs
+++ b/src/platform/x11/error.rs
@@ -5,7 +5,6 @@ use crate::warn;
 use crate::wrappers::xlib::{DisplayOpenFailedError, InitThreadsFailedError};
 use crate::HandlerError;
 use std::fmt::{Display, Formatter};
-use std::sync::mpsc::RecvError;
 use x11_dl::error::OpenError;
 use x11rb::connection::RequestConnection;
 use x11rb::cookie::{Cookie, VoidCookie};

--- a/src/platform/x11/error.rs
+++ b/src/platform/x11/error.rs
@@ -22,8 +22,9 @@ impl Display for FatalError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             FatalError::Connection(e) => e.fmt(f),
-            // TODO: better errors
-            FatalError::SendMainThread => f.write_str("SendMainThread"),
+            FatalError::SendMainThread => {
+                f.write_str("Failed to send callback from X11 thread to main thread")
+            }
         }
     }
 }
@@ -51,7 +52,7 @@ pub enum Error {
     Connect(ConnectError),
     DisplayOpenFailed(DisplayOpenFailedError),
     Handler(HandlerError),
-    Channel(RecvError),
+    MainThreadRecvResult,
     Calloop(calloop::Error),
     RequestFromMainThreadFailed(RequestFailed),
     #[cfg(feature = "opengl")]
@@ -65,7 +66,26 @@ impl Display for Error {
         match self {
             Error::Io(e) => e.fmt(f),
             Self::IdsExhausted => f.write_str("X11 IDs have been exhausted"),
-            _ => todo!(),
+            Error::CreationFailed(e) => write!(f, "Failed to create window: {e}"),
+            Error::Run(e) => write!(f, "Error in running X11 thread: {e}"),
+            Error::DylibOpen(e) => e.fmt(f),
+            Error::InitThreadsFailed(e) => e.fmt(f),
+            Error::X11(e) => write!(f, "X server replied with error: {e:?}"),
+            Error::Connection(e) => e.fmt(f),
+            Error::Parse(e) => e.fmt(f),
+            Error::GetProperty(e) => e.fmt(f),
+            Error::Connect(e) => e.fmt(f),
+            Error::DisplayOpenFailed(e) => e.fmt(f),
+            Error::Handler(e) => e.fmt(f),
+            Error::MainThreadRecvResult => {
+                f.write_str("Failed to receive Window creation response from X11 thread: channel was closed unexpectedly")
+            }
+            Error::Calloop(e) => e.fmt(f),
+            Error::RequestFromMainThreadFailed(e) => e.fmt(f),
+            #[cfg(feature = "opengl")]
+            Error::XLib(e) => e.fmt(f),
+            #[cfg(feature = "opengl")]
+            Error::Gl(e) => e.fmt(f),
         }
     }
 }
@@ -74,7 +94,6 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::Io(e) => Some(e),
-            Error::Channel(e) => Some(e),
             Error::DylibOpen(e) => Some(e),
             Error::Connect(e) => Some(e),
             Error::Handler(e) => Some(e.source()),
@@ -130,12 +149,6 @@ impl From<HandlerError> for Error {
 impl From<calloop::Error> for Error {
     fn from(value: calloop::Error) -> Self {
         Self::Calloop(value)
-    }
-}
-
-impl From<RecvError> for Error {
-    fn from(value: RecvError) -> Self {
-        Self::Channel(value)
     }
 }
 

--- a/src/platform/x11/error.rs
+++ b/src/platform/x11/error.rs
@@ -4,12 +4,39 @@ use crate::platform::x11::xcb_connection::GetPropertyError;
 use crate::warn;
 use crate::wrappers::xlib::{DisplayOpenFailedError, InitThreadsFailedError};
 use crate::HandlerError;
+use std::fmt::{Display, Formatter};
 use std::sync::mpsc::RecvError;
 use x11_dl::error::OpenError;
 use x11rb::connection::RequestConnection;
 use x11rb::cookie::{Cookie, VoidCookie};
 use x11rb::errors::{ConnectError, ConnectionError, ReplyError, ReplyOrIdError};
 use x11rb::x11_utils::{TryParse, X11Error};
+
+#[derive(Debug)]
+pub enum FatalError {
+    Connection(ConnectionError),
+    SendMainThread,
+    ReceiveMainThread,
+}
+
+impl Display for FatalError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FatalError::Connection(e) => e.fmt(f),
+            // TODO: better errors
+            FatalError::SendMainThread => f.write_str("SendMainThread"),
+            FatalError::ReceiveMainThread => f.write_str("ReceiveMainThread"),
+        }
+    }
+}
+
+impl std::error::Error for FatalError {}
+
+impl From<ConnectionError> for FatalError {
+    fn from(err: ConnectionError) -> FatalError {
+        FatalError::Connection(err)
+    }
+}
 
 #[derive(Debug)]
 pub enum Error {
@@ -35,7 +62,7 @@ pub enum Error {
     Gl(super::gl::CreationFailedError),
 }
 
-impl std::fmt::Display for Error {
+impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::Io(e) => e.fmt(f),

--- a/src/platform/x11/error.rs
+++ b/src/platform/x11/error.rs
@@ -1,4 +1,5 @@
 use crate::platform::x11::drag_n_drop::ParseError;
+use crate::platform::x11::window_thread::RequestFailed;
 use crate::platform::x11::xcb_connection::GetPropertyError;
 use crate::warn;
 use crate::wrappers::xlib::{DisplayOpenFailedError, InitThreadsFailedError};
@@ -27,6 +28,7 @@ pub enum Error {
     Handler(HandlerError),
     Channel(RecvError),
     Calloop(calloop::Error),
+    RequestFromMainThreadFailed(RequestFailed),
     #[cfg(feature = "opengl")]
     XLib(crate::wrappers::xlib::XLibError),
     #[cfg(feature = "opengl")]
@@ -109,6 +111,12 @@ impl From<calloop::Error> for Error {
 impl From<RecvError> for Error {
     fn from(value: RecvError) -> Self {
         Self::Channel(value)
+    }
+}
+
+impl From<RequestFailed> for Error {
+    fn from(value: RequestFailed) -> Self {
+        Self::RequestFromMainThreadFailed(value)
     }
 }
 

--- a/src/platform/x11/event_loop.rs
+++ b/src/platform/x11/event_loop.rs
@@ -3,8 +3,9 @@ use super::keyboard::{convert_key_press_event, convert_key_release_event, key_mo
 use super::*;
 use std::result::Result;
 
+use crate::host::HostMainThreadCaller;
 use crate::platform::x11::window_thread::{
-    WindowThreadRequest, WindowThreadResponse, WindowThreadResponseMessage,
+    HostCallback, WindowThreadRequest, WindowThreadResponse, WindowThreadResponseMessage,
 };
 use crate::warn;
 use crate::wrappers::xkbcommon::XkbcommonState;
@@ -34,6 +35,8 @@ pub(crate) struct EventLoop {
     run_error: Option<Error>,
 
     response_sender: mpsc::Sender<WindowThreadResponseMessage>,
+    callback_sender: mpsc::Sender<HostCallback>,
+    main_thread_caller: Option<Box<dyn HostMainThreadCaller>>,
 }
 
 const FRAME_INTERVAL: Duration = Duration::from_millis(15);
@@ -43,6 +46,8 @@ impl EventLoop {
         window: Rc<WindowInner>, handler: Box<dyn WindowHandler>,
         request_receiver: calloop::channel::Channel<WindowThreadRequest>,
         response_sender: mpsc::Sender<WindowThreadResponseMessage>,
+        callback_sender: mpsc::Sender<HostCallback>,
+        main_thread_caller: Option<Box<dyn HostMainThreadCaller>>,
         inner: &mut calloop::EventLoop<'static, Self>,
     ) -> Result<Self, Error> {
         let loop_handle = inner.handle();
@@ -69,6 +74,9 @@ impl EventLoop {
             drag_n_drop: DragNDropState::NoCurrentSession,
             xkb_state: XkbcommonState::new(&window.connection),
             run_error: None,
+            callback_sender,
+            main_thread_caller,
+
             window,
             response_sender,
         })
@@ -89,12 +97,19 @@ impl EventLoop {
             let previous = self.window.store_size(size);
 
             let scale_factor = self.window.scaling_factor.get();
-            if let Err(e) =
-                self.handler.resized(WindowSize::from_physical(size.cast(), scale_factor))
-            {
+            let new_size = WindowSize::from_physical(size.cast(), scale_factor);
+
+            if let Err(e) = self.handler.resized(new_size) {
                 warn!("Window Handler failed to resize: {}", e);
                 self.window.store_size(previous);
                 self.window.xcb_window.resize(previous.cast())?.check_warn();
+            } else {
+                // TODO: only if this wansn't the result of a host request
+                // TODO: do not allocate channel if no host callback is present
+                if let Some(main_thread) = self.main_thread_caller.as_mut() {
+                    self.callback_sender.send(HostCallback::Resized(new_size)).unwrap(); // TODO: unwrap
+                    main_thread.call_main_thread();
+                }
             }
         }
 

--- a/src/platform/x11/event_loop.rs
+++ b/src/platform/x11/event_loop.rs
@@ -134,7 +134,9 @@ impl EventLoop {
             self.window.store_size(previous);
             self.window.xcb_window.resize(previous.cast())?.check_warn();
         } else {
-            // TODO: only if this wansn't the result of a host request
+            // Host requests use resize_immediately, which stops the previous == new_size condition
+            // So if we're here, it's guaranteed not to be from a host request
+
             if let Some(host) = self.main_thread.as_mut() {
                 host.send(HostCallback::Resized {
                     new_size,

--- a/src/platform/x11/event_loop.rs
+++ b/src/platform/x11/event_loop.rs
@@ -107,7 +107,12 @@ impl EventLoop {
                 // TODO: only if this wansn't the result of a host request
                 // TODO: do not allocate channel if no host callback is present
                 if let Some(main_thread) = self.main_thread_caller.as_mut() {
-                    self.callback_sender.send(HostCallback::Resized(new_size)).unwrap(); // TODO: unwrap
+                    self.callback_sender
+                        .send(HostCallback::Resized {
+                            new_size,
+                            previous: WindowSize::from_physical(previous.cast(), scale_factor),
+                        })
+                        .unwrap(); // TODO: unwrap
                     main_thread.call_main_thread();
                 }
             }

--- a/src/platform/x11/event_loop.rs
+++ b/src/platform/x11/event_loop.rs
@@ -4,6 +4,7 @@ use super::*;
 use std::result::Result;
 
 use crate::host::HostMainThreadCaller;
+use crate::platform::x11::error::FatalError;
 use crate::platform::x11::window_thread::{
     HostCallback, WindowThreadRequest, WindowThreadResponse, WindowThreadResponseMessage,
 };
@@ -16,10 +17,35 @@ use calloop::{Interest, LoopSignal, Mode, PostAction};
 use dpi::{PhysicalPosition, PhysicalSize};
 use std::rc::Rc;
 use std::sync::mpsc;
+use std::sync::mpsc::Receiver;
 use std::time::{Duration, Instant};
 use x11rb::connection::Connection;
 use x11rb::errors::ConnectionError;
 use x11rb::protocol::Event as XEvent;
+
+pub struct MainThreadCaller {
+    sender: mpsc::Sender<HostCallback>,
+    caller: Box<dyn HostMainThreadCaller>,
+}
+
+impl MainThreadCaller {
+    pub(crate) fn new(
+        main_thread: Option<Box<dyn HostMainThreadCaller>>,
+    ) -> (Option<Self>, Option<Receiver<HostCallback>>) {
+        let Some(main_thread) = main_thread else {
+            return (None, None);
+        };
+
+        let (sender, receiver) = mpsc::channel();
+        (Some(Self { sender, caller: main_thread }), Some(receiver))
+    }
+
+    pub fn send(&mut self, msg: HostCallback) -> Result<(), FatalError> {
+        self.sender.send(msg).map_err(|_| FatalError::SendMainThread)?;
+        self.caller.call_main_thread();
+        Ok(())
+    }
+}
 
 pub(crate) struct EventLoop {
     handler: Box<dyn WindowHandler>,
@@ -35,8 +61,7 @@ pub(crate) struct EventLoop {
     run_error: Option<Error>,
 
     response_sender: mpsc::Sender<WindowThreadResponseMessage>,
-    callback_sender: mpsc::Sender<HostCallback>,
-    main_thread_caller: Option<Box<dyn HostMainThreadCaller>>,
+    main_thread: Option<MainThreadCaller>,
 }
 
 const FRAME_INTERVAL: Duration = Duration::from_millis(15);
@@ -46,9 +71,7 @@ impl EventLoop {
         window: Rc<WindowInner>, handler: Box<dyn WindowHandler>,
         request_receiver: calloop::channel::Channel<WindowThreadRequest>,
         response_sender: mpsc::Sender<WindowThreadResponseMessage>,
-        callback_sender: mpsc::Sender<HostCallback>,
-        main_thread_caller: Option<Box<dyn HostMainThreadCaller>>,
-        inner: &mut calloop::EventLoop<'static, Self>,
+        main_thread: Option<MainThreadCaller>, inner: &mut calloop::EventLoop<'static, Self>,
     ) -> Result<Self, Error> {
         let loop_handle = inner.handle();
 
@@ -74,8 +97,7 @@ impl EventLoop {
             drag_n_drop: DragNDropState::NoCurrentSession,
             xkb_state: XkbcommonState::new(&window.connection),
             run_error: None,
-            callback_sender,
-            main_thread_caller,
+            main_thread,
 
             window,
             response_sender,
@@ -83,7 +105,7 @@ impl EventLoop {
     }
 
     #[inline]
-    fn drain_xcb_events(&mut self) -> Result<(), ConnectionError> {
+    fn drain_xcb_events(&mut self) -> Result<(), FatalError> {
         // the X server has a tendency to send spurious/extraneous configure notify events when a
         // window is resized, and we need to batch those together and just send one resize event
         // when they've all been coalesced.
@@ -93,28 +115,31 @@ impl EventLoop {
             self.handle_xcb_event(event)?;
         }
 
-        if let Some(size) = self.new_physical_size.take() {
-            let previous = self.window.store_size(size);
+        self.handle_coalesced_resize_events()
+    }
 
-            let scale_factor = self.window.scaling_factor.get();
-            let new_size = WindowSize::from_physical(size.cast(), scale_factor);
+    fn handle_coalesced_resize_events(&mut self) -> Result<(), FatalError> {
+        let Some(new_size) = self.new_physical_size.take() else { return Ok(()) };
+        let previous = self.window.store_size(new_size);
 
-            if let Err(e) = self.handler.resized(new_size) {
-                warn!("Window Handler failed to resize: {}", e);
-                self.window.store_size(previous);
-                self.window.xcb_window.resize(previous.cast())?.check_warn();
-            } else {
-                // TODO: only if this wansn't the result of a host request
-                // TODO: do not allocate channel if no host callback is present
-                if let Some(main_thread) = self.main_thread_caller.as_mut() {
-                    self.callback_sender
-                        .send(HostCallback::Resized {
-                            new_size,
-                            previous: WindowSize::from_physical(previous.cast(), scale_factor),
-                        })
-                        .unwrap(); // TODO: unwrap
-                    main_thread.call_main_thread();
-                }
+        if previous == new_size {
+            return Ok(());
+        };
+
+        let scale_factor = self.window.scaling_factor.get();
+        let new_size = WindowSize::from_physical(new_size.cast(), scale_factor);
+
+        if let Err(e) = self.handler.resized(new_size) {
+            warn!("Window Handler failed to resize: {}", e);
+            self.window.store_size(previous);
+            self.window.xcb_window.resize(previous.cast())?.check_warn();
+        } else {
+            // TODO: only if this wansn't the result of a host request
+            if let Some(host) = self.main_thread.as_mut() {
+                host.send(HostCallback::Resized {
+                    new_size,
+                    previous: WindowSize::from_physical(previous.cast(), scale_factor),
+                })?;
             }
         }
 
@@ -177,7 +202,7 @@ impl EventLoop {
         }
     }
 
-    fn handle_connection_event_ready(&mut self) -> Result<PostAction, ConnectionError> {
+    fn handle_connection_event_ready(&mut self) -> Result<PostAction, FatalError> {
         self.drain_xcb_events()?;
 
         Ok(PostAction::Continue)
@@ -213,6 +238,15 @@ impl EventLoop {
         inner.run(None, &mut self, Self::handle_idle)?;
 
         self.handle_event(Event::Window(WindowEvent::WillClose));
+
+        // If the event loop doesn't stop because the host asked it to, then we should notify it
+        if !self.window.main_thread_shared.is_stop_host_requested() {
+            if let Some(main_thread) = self.main_thread.as_mut() {
+                if let Err(e) = main_thread.send(HostCallback::Destroyed) {
+                    warn!("Could not notify host that X11 thread is stopping: {}", e)
+                }
+            }
+        }
 
         if let Some(err) = self.run_error {
             return Err(err);

--- a/src/platform/x11/gl.rs
+++ b/src/platform/x11/gl.rs
@@ -20,6 +20,24 @@ pub enum CreationFailedError {
     OpenError(OpenError),
 }
 
+impl Display for CreationFailedError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CreationFailedError::NoValidFBConfig => {
+                f.write_str("Could not find a valid Framebuffer configuration")
+            }
+            CreationFailedError::NoVisual => {
+                f.write_str("Could not find a matching visual configuration")
+            }
+            CreationFailedError::GetProcAddressFailed => f.write_str("GetProcAddress failed"),
+            CreationFailedError::MakeCurrentFailed => f.write_str("MakeCurrent failed"),
+            CreationFailedError::ContextCreationFailed => f.write_str("Faile to create GL context"),
+            CreationFailedError::X11Error(e) => e.fmt(f),
+            CreationFailedError::OpenError(e) => e.fmt(f),
+        }
+    }
+}
+
 pub type GlContext = Rc<GlContextInner>;
 
 pub struct GlContextInner {

--- a/src/platform/x11/window_shared.rs
+++ b/src/platform/x11/window_shared.rs
@@ -186,7 +186,7 @@ impl WindowInner {
         Ok(())
     }
 
-    pub fn resize_later(&self, size: Size) -> Result<()> {
+    pub fn resize(&self, size: Size) -> Result<()> {
         let new_physical_size = size.to_physical(self.scaling_factor.get());
         self.xcb_window.resize(new_physical_size)?.check()?;
 

--- a/src/platform/x11/window_shared.rs
+++ b/src/platform/x11/window_shared.rs
@@ -61,7 +61,7 @@ pub(crate) struct WindowInner {
     pub(crate) is_focused: Cell<bool>,
     pub(crate) loop_signal: LoopSignal,
 
-    main_thread_shared: Arc<WindowThreadShared>,
+    pub(crate) main_thread_shared: Arc<WindowThreadShared>,
 }
 
 impl WindowInner {
@@ -186,7 +186,7 @@ impl WindowInner {
         Ok(())
     }
 
-    pub fn resize(&self, size: Size) -> Result<()> {
+    pub fn resize_later(&self, size: Size) -> Result<()> {
         let new_physical_size = size.to_physical(self.scaling_factor.get());
         self.xcb_window.resize(new_physical_size)?.check()?;
 
@@ -211,9 +211,11 @@ impl WindowInner {
             warn!("Window Handler failed to resize: {}. Reverting to previous size", &e);
             self.store_size(previous);
             return Err(e.into());
-        } else {
-            self.xcb_window.resize(new_size.cast())?.check()?; // Will not call handler, as size is the same as above.
         }
+
+        self.xcb_window.resize(new_size.cast())?.check()?; // Will not call handler, as size is the same as above.
+
+        // These come from the Host, no need to notify it about the new size
 
         Ok(())
     }

--- a/src/platform/x11/window_shared.rs
+++ b/src/platform/x11/window_shared.rs
@@ -188,7 +188,7 @@ impl WindowInner {
 
     pub fn resize(&self, size: Size) -> Result<()> {
         let new_physical_size = size.to_physical(self.scaling_factor.get());
-        self.xcb_window.resize(new_physical_size)?;
+        self.xcb_window.resize(new_physical_size)?.check()?;
 
         // This will trigger a `ConfigureNotify` event which will in turn change `self.window_info`
         // and notify the window handler about it
@@ -205,14 +205,14 @@ impl WindowInner {
             return Ok(());
         };
 
-        self.xcb_window.resize(new_size.cast())?; // Will not call handler, as size is the same as above.
-
         if let Err(e) =
             handler.resized(WindowSize::from_physical(new_size.cast(), self.scaling_factor.get()))
         {
             warn!("Window Handler failed to resize: {}. Reverting to previous size", &e);
             self.store_size(previous);
             return Err(e.into());
+        } else {
+            self.xcb_window.resize(new_size.cast())?.check()?; // Will not call handler, as size is the same as above.
         }
 
         Ok(())

--- a/src/platform/x11/window_thread.rs
+++ b/src/platform/x11/window_thread.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::handler::WindowHandlerBuilder;
 use crate::host::{Host, HostCallbacks, HostMainThreadCaller};
-use crate::platform::x11::event_loop::EventLoop;
+use crate::platform::x11::event_loop::{EventLoop, MainThreadCaller};
 use crate::platform::x11::window_shared::WindowInner;
 use crate::warn;
 use crate::{WindowContext, WindowOpenOptions, WindowSize};
@@ -20,6 +20,7 @@ pub(crate) struct WindowThreadShared {
     scaling_factor: AtomicU64,
     size: AtomicU32,
     final_error: Mutex<Option<String>>,
+    stopped_requested_from_host: AtomicBool,
 }
 
 impl WindowThreadShared {
@@ -29,6 +30,7 @@ impl WindowThreadShared {
             final_error: None.into(),
             size: 0.into(),
             scaling_factor: 0.into(),
+            stopped_requested_from_host: false.into(),
         }
     }
 
@@ -52,6 +54,10 @@ impl WindowThreadShared {
     pub fn set_scaling_factor(&self, scale_factor: f64) {
         self.scaling_factor
             .store(u64::from_be_bytes(scale_factor.to_ne_bytes()), Ordering::Relaxed);
+    }
+
+    pub fn is_stop_host_requested(&self) -> bool {
+        self.stopped_requested_from_host.load(Ordering::Relaxed)
     }
 }
 
@@ -78,7 +84,7 @@ pub struct WindowThreadHandle {
 
     request_sender: calloop::channel::SyncSender<WindowThreadRequest>,
     response_receiver: mpsc::Receiver<WindowThreadResponseMessage>,
-    callback_receiver: mpsc::Receiver<HostCallback>,
+    callback_receiver: Option<mpsc::Receiver<HostCallback>>,
     host_callbacks: Option<Box<dyn HostCallbacks>>,
 }
 
@@ -90,11 +96,10 @@ impl WindowThreadHandle {
         let shared = Arc::new(WindowThreadShared::new());
         let (request_sender, request_receiver) = calloop::channel::sync_channel(1);
         let (response_sender, response_receiver) = mpsc::channel();
-        let (callback_sender, callback_receiver) = mpsc::channel();
+        let (main_thread_caller, main_thread_receiver) = MainThreadCaller::new(host.main_thread);
 
         let join_handle = {
             let shared = shared.clone();
-            let main_thread_caller = host.main_thread;
 
             thread::spawn(move || {
                 let thread = match WindowThread::create(
@@ -103,7 +108,6 @@ impl WindowThreadHandle {
                     shared,
                     request_receiver,
                     response_sender,
-                    callback_sender,
                     main_thread_caller,
                 ) {
                     Err(e) => return tx.send_error(e),
@@ -125,7 +129,7 @@ impl WindowThreadHandle {
             request_sender,
             response_receiver,
             host_callbacks: host.callbacks,
-            callback_receiver,
+            callback_receiver: main_thread_receiver,
         })
     }
 
@@ -145,12 +149,12 @@ impl WindowThreadHandle {
     }
 
     fn request(&self, req: WindowThreadRequest) -> Result<()> {
-        self.request_sender.send(req).map_err(|_| RequestFailed::SendError)?;
-        let result = self.response_receiver.recv().map_err(|_| RequestFailed::RecvError)?;
+        self.request_sender.send(req).map_err(|_| RequestFailed::Send)?;
+        let result = self.response_receiver.recv().map_err(|_| RequestFailed::Recv)?;
 
         match result {
             Ok(WindowThreadResponse::Ok) => Ok(()),
-            Err(e) => Err(RequestFailed::ResponseError(e).into()),
+            Err(e) => Err(RequestFailed::Response(e).into()),
         }
     }
 
@@ -174,7 +178,9 @@ impl WindowThreadHandle {
 
     pub fn handle_main_thread_callback(&mut self) {
         loop {
-            let Some(callback) = self.callback_receiver.try_recv().ok() else { return };
+            let Some(receiver) = self.callback_receiver.as_mut() else { return };
+            let Some(callback) = receiver.try_recv().ok() else { return };
+
             self.handle_main_thread_message(callback);
         }
     }
@@ -202,11 +208,12 @@ impl WindowThreadHandle {
 
 impl Drop for WindowThreadHandle {
     fn drop(&mut self) {
+        self.shared.stopped_requested_from_host.store(true, Ordering::Relaxed);
         self.loop_signal.stop();
         self.loop_signal.wakeup();
 
         if let Err(e) = self.run_until_closed() {
-            crate::warn!("Error while closing window: {}", e)
+            warn!("Error while closing window: {}", e)
         }
     }
 }
@@ -224,17 +231,17 @@ struct WindowThread {
 
 #[derive(Debug)]
 pub enum RequestFailed {
-    SendError,
-    RecvError,
-    ResponseError(String),
+    Send,
+    Recv,
+    Response(String),
 }
 
 impl Display for RequestFailed {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            RequestFailed::SendError => f.write_str("Request to X11 thread failed: Could not send request (X11 thread disconnected)"),
-            RequestFailed::RecvError => f.write_str("Request to X11 thread failed: Could not receive response (X11 thread disconnected)"),
-            RequestFailed::ResponseError(e) => f.write_str(e),
+            RequestFailed::Send => f.write_str("Request to X11 thread failed: Could not send request (X11 thread disconnected)"),
+            RequestFailed::Recv => f.write_str("Request to X11 thread failed: Could not receive response (X11 thread disconnected)"),
+            RequestFailed::Response(e) => f.write_str(e),
         }
     }
 }
@@ -244,21 +251,13 @@ impl WindowThread {
         options: WindowOpenOptions, handler: WindowHandlerBuilder, shared: Arc<WindowThreadShared>,
         receiver: calloop::channel::Channel<WindowThreadRequest>,
         sender: mpsc::Sender<WindowThreadResponseMessage>,
-        callback_sender: mpsc::Sender<HostCallback>,
-        main_thread_caller: Option<Box<dyn HostMainThreadCaller>>,
+        main_thread_caller: Option<MainThreadCaller>,
     ) -> Result<Self> {
         let mut ev_loop = calloop::EventLoop::try_new()?;
         let inner = WindowInner::create(options, &ev_loop, shared.clone())?;
         let handler = handler.build(WindowContext::new(Rc::clone(&inner)))?;
-        let event_loop = EventLoop::new(
-            inner,
-            handler,
-            receiver,
-            sender,
-            callback_sender,
-            main_thread_caller,
-            &mut ev_loop,
-        )?;
+        let event_loop =
+            EventLoop::new(inner, handler, receiver, sender, main_thread_caller, &mut ev_loop)?;
 
         Ok(Self { event_loop, ev_loop, shared })
     }

--- a/src/platform/x11/window_thread.rs
+++ b/src/platform/x11/window_thread.rs
@@ -3,6 +3,7 @@ use crate::handler::WindowHandlerBuilder;
 use crate::host::{Host, HostCallbacks, HostMainThreadCaller};
 use crate::platform::x11::event_loop::EventLoop;
 use crate::platform::x11::window_shared::WindowInner;
+use crate::warn;
 use crate::{WindowContext, WindowOpenOptions, WindowSize};
 use calloop::LoopSignal;
 use dpi::{PhysicalSize, Size};
@@ -66,7 +67,7 @@ pub enum WindowThreadResponse {
 pub type WindowThreadResponseMessage = core::result::Result<WindowThreadResponse, String>;
 
 pub enum HostCallback {
-    Resized(WindowSize),
+    Resized { new_size: WindowSize, previous: WindowSize },
     Destroyed,
 }
 
@@ -144,12 +145,12 @@ impl WindowThreadHandle {
     }
 
     fn request(&self, req: WindowThreadRequest) -> Result<()> {
-        self.request_sender.send(req).unwrap(); // TODO: handle error
-        let result = self.response_receiver.recv().unwrap(); // TODO: handle error
+        self.request_sender.send(req).map_err(|_| RequestFailed::SendError)?;
+        let result = self.response_receiver.recv().map_err(|_| RequestFailed::RecvError)?;
 
         match result {
             Ok(WindowThreadResponse::Ok) => Ok(()),
-            Err(e) => Err(Error::Run(e)), // TODO: better error type?
+            Err(e) => Err(RequestFailed::ResponseError(e).into()),
         }
     }
 
@@ -172,12 +173,27 @@ impl WindowThreadHandle {
     }
 
     pub fn handle_main_thread_callback(&mut self) {
+        loop {
+            let Some(callback) = self.callback_receiver.try_recv().ok() else { return };
+            self.handle_main_thread_message(callback);
+        }
+    }
+
+    fn handle_main_thread_message(&mut self, msg: HostCallback) {
         let Some(host_callbacks) = self.host_callbacks.as_mut() else { return };
-        for msg in self.callback_receiver.try_iter() {
-            match msg {
-                HostCallback::Destroyed => host_callbacks.destroyed(),
-                HostCallback::Resized(size) => {
-                    host_callbacks.resized(size).unwrap();
+
+        match msg {
+            HostCallback::Destroyed => host_callbacks.destroyed(),
+            HostCallback::Resized { new_size: new, previous } => {
+                if let Err(e) = host_callbacks.request_resize(new) {
+                    warn!("Host failed to resize parent window: {}. Reverting.", e);
+
+                    if let Err(e) = self.resize(previous.physical.into()) {
+                        warn!(
+                            "Failed to revert to previous size while handling previous error: {}",
+                            e
+                        );
+                    }
                 }
             }
         }
@@ -204,6 +220,23 @@ struct WindowThread {
     event_loop: EventLoop,
     ev_loop: calloop::EventLoop<'static, EventLoop>,
     shared: Arc<WindowThreadShared>,
+}
+
+#[derive(Debug)]
+pub enum RequestFailed {
+    SendError,
+    RecvError,
+    ResponseError(String),
+}
+
+impl Display for RequestFailed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RequestFailed::SendError => f.write_str("Request to X11 thread failed: Could not send request (X11 thread disconnected)"),
+            RequestFailed::RecvError => f.write_str("Request to X11 thread failed: Could not receive response (X11 thread disconnected)"),
+            RequestFailed::ResponseError(e) => f.write_str(e),
+        }
+    }
 }
 
 impl WindowThread {

--- a/src/platform/x11/window_thread.rs
+++ b/src/platform/x11/window_thread.rs
@@ -128,7 +128,7 @@ impl WindowThreadHandle {
             loop_signal,
             request_sender,
             response_receiver,
-            host_callbacks: host.callbacks,
+            host_callbacks: host.callbacks.map(|c| c.into_inner()),
             callback_receiver: main_thread_receiver,
         })
     }

--- a/src/platform/x11/window_thread.rs
+++ b/src/platform/x11/window_thread.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::handler::WindowHandlerBuilder;
+use crate::host::Host;
 use crate::platform::x11::event_loop::EventLoop;
 use crate::platform::x11::window_shared::WindowInner;
 use crate::{WindowContext, WindowOpenOptions, WindowSize};
@@ -75,7 +76,7 @@ pub struct WindowThreadHandle {
 
 impl WindowThreadHandle {
     pub fn create_window(
-        options: WindowOpenOptions, handler: WindowHandlerBuilder,
+        options: WindowOpenOptions, handler: WindowHandlerBuilder, host: Host,
     ) -> Result<Self> {
         let (tx, rx) = result_channel();
         let shared = Arc::new(WindowThreadShared::new());
@@ -84,6 +85,7 @@ impl WindowThreadHandle {
 
         let join_handle = {
             let shared = shared.clone();
+            let main_thread_caller = host.main_thread;
 
             thread::spawn(move || {
                 let thread = match WindowThread::create(

--- a/src/platform/x11/window_thread.rs
+++ b/src/platform/x11/window_thread.rs
@@ -298,7 +298,8 @@ impl WindowResultSender {
 struct WindowResultReceiver(mpsc::Receiver<WindowOpenResult>);
 impl WindowResultReceiver {
     pub fn receive(self) -> Result<LoopSignal> {
-        let result = self.0.recv()?;
+        let result = self.0.recv().map_err(|_| Error::MainThreadRecvResult)?;
+
         match result {
             WindowOpenResult::Error(e) => Err(Error::CreationFailed(e)),
             WindowOpenResult::Success { loop_signal } => Ok(loop_signal),

--- a/src/platform/x11/window_thread.rs
+++ b/src/platform/x11/window_thread.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::handler::WindowHandlerBuilder;
-use crate::host::{Host, HostCallbacks, HostMainThreadCaller};
+use crate::host::{Host, HostCallbacks};
 use crate::platform::x11::event_loop::{EventLoop, MainThreadCaller};
 use crate::platform::x11::window_shared::WindowInner;
 use crate::warn;

--- a/src/platform/x11/window_thread.rs
+++ b/src/platform/x11/window_thread.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::handler::WindowHandlerBuilder;
-use crate::host::Host;
+use crate::host::{Host, HostCallbacks, HostMainThreadCaller};
 use crate::platform::x11::event_loop::EventLoop;
 use crate::platform::x11::window_shared::WindowInner;
 use crate::{WindowContext, WindowOpenOptions, WindowSize};
@@ -65,6 +65,11 @@ pub enum WindowThreadResponse {
 
 pub type WindowThreadResponseMessage = core::result::Result<WindowThreadResponse, String>;
 
+pub enum HostCallback {
+    Resized(WindowSize),
+    Destroyed,
+}
+
 pub struct WindowThreadHandle {
     shared: Arc<WindowThreadShared>,
     loop_signal: LoopSignal,
@@ -72,6 +77,8 @@ pub struct WindowThreadHandle {
 
     request_sender: calloop::channel::SyncSender<WindowThreadRequest>,
     response_receiver: mpsc::Receiver<WindowThreadResponseMessage>,
+    callback_receiver: mpsc::Receiver<HostCallback>,
+    host_callbacks: Option<Box<dyn HostCallbacks>>,
 }
 
 impl WindowThreadHandle {
@@ -82,6 +89,7 @@ impl WindowThreadHandle {
         let shared = Arc::new(WindowThreadShared::new());
         let (request_sender, request_receiver) = calloop::channel::sync_channel(1);
         let (response_sender, response_receiver) = mpsc::channel();
+        let (callback_sender, callback_receiver) = mpsc::channel();
 
         let join_handle = {
             let shared = shared.clone();
@@ -94,6 +102,8 @@ impl WindowThreadHandle {
                     shared,
                     request_receiver,
                     response_sender,
+                    callback_sender,
+                    main_thread_caller,
                 ) {
                     Err(e) => return tx.send_error(e),
                     Ok(thread) => thread,
@@ -113,6 +123,8 @@ impl WindowThreadHandle {
             loop_signal,
             request_sender,
             response_receiver,
+            host_callbacks: host.callbacks,
+            callback_receiver,
         })
     }
 
@@ -158,6 +170,18 @@ impl WindowThreadHandle {
     pub fn is_open(&self) -> bool {
         !self.shared.stopped.load(Ordering::Relaxed)
     }
+
+    pub fn handle_main_thread_callback(&mut self) {
+        let Some(host_callbacks) = self.host_callbacks.as_mut() else { return };
+        for msg in self.callback_receiver.try_iter() {
+            match msg {
+                HostCallback::Destroyed => host_callbacks.destroyed(),
+                HostCallback::Resized(size) => {
+                    host_callbacks.resized(size).unwrap();
+                }
+            }
+        }
+    }
 }
 
 impl Drop for WindowThreadHandle {
@@ -187,11 +211,21 @@ impl WindowThread {
         options: WindowOpenOptions, handler: WindowHandlerBuilder, shared: Arc<WindowThreadShared>,
         receiver: calloop::channel::Channel<WindowThreadRequest>,
         sender: mpsc::Sender<WindowThreadResponseMessage>,
+        callback_sender: mpsc::Sender<HostCallback>,
+        main_thread_caller: Option<Box<dyn HostMainThreadCaller>>,
     ) -> Result<Self> {
         let mut ev_loop = calloop::EventLoop::try_new()?;
         let inner = WindowInner::create(options, &ev_loop, shared.clone())?;
         let handler = handler.build(WindowContext::new(Rc::clone(&inner)))?;
-        let event_loop = EventLoop::new(inner, handler, receiver, sender, &mut ev_loop)?;
+        let event_loop = EventLoop::new(
+            inner,
+            handler,
+            receiver,
+            sender,
+            callback_sender,
+            main_thread_caller,
+            &mut ev_loop,
+        )?;
 
         Ok(Self { event_loop, ev_loop, shared })
     }

--- a/src/platform/x11/xcb_window.rs
+++ b/src/platform/x11/xcb_window.rs
@@ -1,3 +1,4 @@
+use crate::platform::x11::error::CookieExt;
 use crate::platform::x11::visual_info::WindowVisualConfig;
 use crate::platform::X11Connection;
 use dpi::PhysicalSize;
@@ -111,8 +112,9 @@ impl XcbWindow {
 
 impl Drop for XcbWindow {
     fn drop(&mut self) {
-        // TODO: log error
-        let Ok(cookie) = self.connection.conn.destroy_window(self.window_id.get()) else { return };
-        let _ = cookie.check();
+        match self.connection.conn.destroy_window(self.window_id.get()) {
+            Err(e) => crate::warn!("Failed to send request to destroy X window: {}", e),
+            Ok(cookie) => cookie.check_warn(),
+        }
     }
 }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -7,8 +7,8 @@ pub use tracing::{error, warn};
 mod tracing_impl {
     macro_rules! __warn {
         ($($f:tt)*) => {
-            #[allow(unused, dead_code)]
             {
+                #[allow(unused, dead_code)]
                 let _ = ($($f)*);
             }
         };

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,4 +1,5 @@
 use crate::handler::WindowHandlerBuilder;
+use crate::host::Host;
 use crate::platform;
 use crate::*;
 use dpi::{LogicalSize, PhysicalSize, Pixel, Size};
@@ -69,15 +70,28 @@ impl WindowHandle {
     pub fn is_open(&self) -> bool {
         self.window_handle.is_open()
     }
+
+    pub fn host_main_thread_callback(&mut self) {
+        todo!()
+    }
 }
 
 pub fn create_window<H: WindowHandler>(
     builder: WindowOpenOptions,
     handler: impl FnOnce(WindowContext) -> Result<H, HandlerError> + Send + 'static,
 ) -> Result<WindowHandle, Error> {
+    create_window_with_host(builder, handler, None)
+}
+
+pub fn create_window_with_host<H: WindowHandler>(
+    builder: WindowOpenOptions,
+    handler: impl FnOnce(WindowContext) -> Result<H, HandlerError> + Send + 'static,
+    host: impl Into<Option<Host>>,
+) -> Result<WindowHandle, Error> {
     Ok(WindowHandle::new(platform::WindowHandle::create_window(
         builder,
         WindowHandlerBuilder::new(handler),
+        host.into().unwrap_or_else(Host::default),
     )?))
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -78,6 +78,15 @@ impl WindowHandle {
         self.window_handle.is_open()
     }
 
+    /// Performs the work the window thread had scheduled for the main thread.
+    ///
+    /// This must be called back on the main thread, as a response to [`HostMainThreadCaller::call_main_thread`](host::HostMainThreadCaller::call_main_thread).
+    ///
+    /// # Platform compatibility notes
+    ///
+    /// Only the X11 platform has a separate window thread, so this is only needed to run host callbacks on X11.
+    ///
+    /// On Windows and macOS, this is always a no-op.
     #[inline]
     pub fn host_main_thread_callback(&mut self) {
         self.window_handle.handle_main_thread_callback()

--- a/src/window.rs
+++ b/src/window.rs
@@ -12,16 +12,19 @@ pub struct WindowHandle {
 }
 
 impl WindowHandle {
+    #[inline]
     fn new(window_handle: platform::WindowHandle) -> Self {
         Self { window_handle, phantom: PhantomData }
     }
 
+    #[inline]
     pub fn run_until_closed(self) -> Result<(), Error> {
         self.window_handle.run_until_closed()?;
         Ok(())
     }
 
     /// The current size of the window.
+    #[inline]
     pub fn size(&self) -> WindowSize {
         self.window_handle.size()
     }
@@ -29,6 +32,7 @@ impl WindowHandle {
     /// Resizes the window to the given [`Size`].
     ///
     /// The `size` can be provided in either physical or logical pixels.
+    #[inline]
     pub fn resize(&self, size: Size) -> Result<(), Error> {
         self.window_handle.resize(size)?;
         Ok(())
@@ -48,6 +52,7 @@ impl WindowHandle {
     /// On X11, this value is used if no `Xft.dpi`setting is set.
     ///
     /// On macOS, this function is always a no-op.
+    #[inline]
     pub fn suggest_fallback_scale_factor(&self, scale_factor: f64) -> Result<(), Error> {
         self.window_handle.suggest_scale_factor(scale_factor)?;
         Ok(())
@@ -61,21 +66,25 @@ impl WindowHandle {
     /// this call.
     ///
     /// Calling this method is more explicit, but otherwise identical to just dropping this [`WindowHandle`].
+    #[inline]
     pub fn close(self) {
         drop(self)
     }
 
     /// Returns `true` if the window is still open, and returns `false`
     /// if the window was closed/dropped.
+    #[inline]
     pub fn is_open(&self) -> bool {
         self.window_handle.is_open()
     }
 
+    #[inline]
     pub fn host_main_thread_callback(&mut self) {
         self.window_handle.handle_main_thread_callback()
     }
 }
 
+#[inline]
 pub fn create_window<H: WindowHandler>(
     builder: WindowOpenOptions,
     handler: impl FnOnce(WindowContext) -> Result<H, HandlerError> + Send + 'static,

--- a/src/window.rs
+++ b/src/window.rs
@@ -72,7 +72,7 @@ impl WindowHandle {
     }
 
     pub fn host_main_thread_callback(&mut self) {
-        todo!()
+        self.window_handle.handle_main_thread_callback()
     }
 }
 

--- a/src/window_open_options.rs
+++ b/src/window_open_options.rs
@@ -41,7 +41,11 @@ impl WindowOpenOptions {
     }
 
     #[inline]
-    pub fn with_parent(mut self, parent: &impl HasWindowHandle) -> Self {
+    pub fn with_parent<'a, P: HasWindowHandle + 'a>(
+        mut self, parent: impl Into<Option<&'a P>>,
+    ) -> Self {
+        let Some(parent) = parent.into() else { return self };
+
         let parent = match ParentWindowHandle::extract(parent) {
             Ok(parent) => parent,
             Err(e) => {

--- a/src/wrappers/appkit/view.rs
+++ b/src/wrappers/appkit/view.rs
@@ -152,7 +152,7 @@ pub trait ViewImpl: Sized {
     fn become_first_responder(this: ViewRef<Self>) -> bool;
     fn resign_first_responder(this: ViewRef<Self>) -> bool;
     fn window_should_close(this: ViewRef<Self>) -> bool;
-    fn view_did_change_backing_properties(this: ViewRef<Self>);
+    fn view_did_change_backing_properties(this: ViewRef<Self>, from_host: bool);
     fn hit_test(this: ViewRef<'_, Self>, point: NSPoint) -> Option<&NSView>;
     fn view_will_move_to_window(this: ViewRef<Self>, new_window: Option<&NSWindow>);
     fn update_tracking_areas(this: ViewRef<Self>);

--- a/src/wrappers/appkit/view/implementation.rs
+++ b/src/wrappers/appkit/view/implementation.rs
@@ -187,7 +187,7 @@ extern "C-unwind" fn view_did_change_backing_properties<V: ViewImpl>(
     this: &View<V>, _: Sel, _: &AnyObject,
 ) {
     let Some(inner) = this.inner_ref() else { return };
-    V::view_did_change_backing_properties(inner);
+    V::view_did_change_backing_properties(inner, true);
 }
 
 extern "C-unwind" fn hit_test<V: ViewImpl>(


### PR DESCRIPTION
This PR introduces a new `Host` type, which can be optionally passed to `create_window` and will provide the ability for baseview to trigger host callbacks when it needs to act on the parent window.

Currently, the `Host` callbacks supports requesting a parent resize (for plugin -> host window resizing), and notifying the host that the parent window has been destroyed.