### PR TITLE
Add HandlerError::from_boxed

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -51,17 +51,22 @@ impl From<HandlerError> for Error {
 ///
 /// [`Error`]: std::error::Error
 pub struct HandlerError {
-    inner: Box<dyn std::error::Error + 'static>,
+    inner: Box<dyn std::error::Error>,
 }
 
 impl HandlerError {
+    #[inline]
+    pub fn from_boxed(error: Box<dyn std::error::Error>) -> Self {
+        Self { inner: error }
+    }
+
     #[inline]
     pub fn source(&self) -> &(dyn std::error::Error + 'static) {
         self.inner.as_ref()
     }
 
     #[inline]
-    pub fn into_inner(self) -> Box<dyn std::error::Error + 'static> {
+    pub fn into_inner(self) -> Box<dyn std::error::Error> {
         self.inner
     }
 }


### PR DESCRIPTION
I found there was no easy way to create a `HandlerError` from an already boxed error.

Until Rust gets negative traits, we can't have an `impl From<Box<dyn Error>> for HandlerError` implementation. So for now I just added a `from_boxed` method.

There were also a couple of places with unecessary `'static` labels (`Box` already implies that the contents are `'static`), so I removed them.