### PR TITLE
Make Hand cursor show a pointing hand on macOS

### DIFF
--- a/src/platform/macos/cursor.rs
+++ b/src/platform/macos/cursor.rs
@@ -15,7 +15,7 @@ impl From<MouseCursor> for Cursor {
     fn from(cursor: MouseCursor) -> Self {
         match cursor {
             MouseCursor::Default => Cursor::Native(NSCursor::arrowCursor),
-            MouseCursor::Hand => Cursor::Native(NSCursor::openHandCursor),
+            MouseCursor::Hand => Cursor::Native(NSCursor::pointingHandCursor),
             MouseCursor::HandGrabbing => Cursor::Native(NSCursor::closedHandCursor),
             MouseCursor::Text => Cursor::Native(NSCursor::IBeamCursor),
             MouseCursor::VerticalText => Cursor::Native(NSCursor::IBeamCursorForVerticalLayout),


### PR DESCRIPTION
This PR fixes `MouseCursor::Hand` incorrectly showing an open hand on macOS by making that cursor a `NSCursor::pointerHand` instead of a `NSCursor::openHand`.

This makes the macOS implementation of that cursor consistent with Windows and Linux which both show a pointing hand (respectively `IDC_HAND` and `hand2`)

Relevant docs:
https://developer.apple.com/documentation/appkit/nscursor