### PR TITLE
OpenGL: Deprecate vsync & double_buffer options

### DIFF
--- a/src/gl.rs
+++ b/src/gl.rs
@@ -13,11 +13,17 @@ pub struct GlConfig {
     pub stencil_bits: u8,
     pub samples: Option<u8>,
     pub srgb: bool,
+    #[deprecated(since = "0.3.3", note = "This is now always enabled.")]
     pub double_buffer: bool,
+    #[deprecated(
+        since = "0.3.3",
+        note = "This should never be enabled in plugins, it blocks the main thread until the next frame."
+    )]
     pub vsync: bool,
 }
 
 impl Default for GlConfig {
+    #[allow(deprecated, reason = "This is the Default impl, we need to set these still.")]
     fn default() -> Self {
         GlConfig {
             version: (3, 2),

--- a/src/platform/macos/gl.rs
+++ b/src/platform/macos/gl.rs
@@ -90,6 +90,7 @@ impl GlContext {
             NSOpenGLPFADepthSize, config.depth_bits as u32,
             NSOpenGLPFAStencilSize, config.stencil_bits as u32,
             NSOpenGLPFAAccelerated,
+            NSOpenGLPFADoubleBuffer,
         ];
 
         if let Some(samples) = config.samples {
@@ -99,10 +100,6 @@ impl GlContext {
                 NSOpenGLPFASampleBuffers, 1,
                 NSOpenGLPFASamples, samples as u32,
             ]);
-        }
-
-        if config.double_buffer {
-            attrs.push(NSOpenGLPFADoubleBuffer);
         }
 
         attrs.push(0);
@@ -131,13 +128,6 @@ impl GlContext {
 
         // NSOpenGlView::openGLContext is not documented to possibly return NULL.
         let Some(context) = view.openGLContext() else { unreachable!() };
-
-        let value = config.vsync as i32;
-
-        // SAFETY: pointer is a valid &i32, and is valid for SwapInterval
-        unsafe {
-            context.setValues_forParameter((&value).into(), NSOpenGLContextParameter::SwapInterval);
-        }
 
         let framework_name = CFString::from_static_str("com.apple.opengl");
         let gl_bundle = CFBundle::bundle_with_identifier(Some(&framework_name))

--- a/src/platform/macos/gl.rs
+++ b/src/platform/macos/gl.rs
@@ -7,8 +7,8 @@ use objc2::rc::Retained;
 use objc2::AllocAnyThread;
 use objc2::{MainThreadMarker, MainThreadOnly};
 use objc2_app_kit::{
-    NSOpenGLContext, NSOpenGLContextParameter, NSOpenGLPFAAccelerated, NSOpenGLPFAAlphaSize,
-    NSOpenGLPFAColorSize, NSOpenGLPFADepthSize, NSOpenGLPFADoubleBuffer, NSOpenGLPFAMultisample,
+    NSOpenGLContext, NSOpenGLPFAAccelerated, NSOpenGLPFAAlphaSize, NSOpenGLPFAColorSize,
+    NSOpenGLPFADepthSize, NSOpenGLPFADoubleBuffer, NSOpenGLPFAMultisample,
     NSOpenGLPFAOpenGLProfile, NSOpenGLPFASampleBuffers, NSOpenGLPFASamples, NSOpenGLPFAStencilSize,
     NSOpenGLPixelFormat, NSOpenGLProfileVersion3_2Core, NSOpenGLProfileVersion4_1Core,
     NSOpenGLProfileVersionLegacy, NSOpenGLView, NSView,

--- a/src/platform/win/gl.rs
+++ b/src/platform/win/gl.rs
@@ -49,10 +49,6 @@ impl GlContextInner {
             }
         };
 
-        if let Err(e) | Ok(Err(e)) = wgl_ctx.with_current(&hdc, || extra.set_vsync(config.vsync)) {
-            warn!("Could not set vsync: {}", e);
-        }
-
         Ok(Self { hdc, wgl_ctx, gl_library })
     }
 

--- a/src/platform/x11/gl.rs
+++ b/src/platform/x11/gl.rs
@@ -82,10 +82,6 @@ impl GlContextInner {
                 return Err(CreationFailedError::GetProcAddressFailed.into());
             };
 
-            let Some(swap_interval) = glx.get_glx_swap_interval_ext() else {
-                return Err(CreationFailedError::GetProcAddressFailed.into());
-            };
-
             let context = create_context.call(
                 xlib_connection,
                 &config.gl_config,
@@ -93,33 +89,12 @@ impl GlContextInner {
                 error_handler,
             )?;
 
-            let window_id = window.id().get().into();
-            // Create context object here so that error or panic will properly free the context
-            let context = GlContextInner {
+            Ok(Rc::new(GlContextInner {
                 glx,
                 window: window.id(),
                 connection: Rc::clone(&connection),
                 context,
-            };
-
-            unsafe {
-                context.glx.with_current_context(
-                    xlib_connection,
-                    window_id,
-                    context.context,
-                    error_handler,
-                    || {
-                        swap_interval(
-                            xlib_connection.as_raw(),
-                            window_id,
-                            config.gl_config.vsync as i32,
-                        );
-                        error_handler.check()
-                    },
-                )??;
-            }
-
-            Ok(Rc::new(context))
+            }))
         })
     }
 

--- a/src/wrappers/glx.rs
+++ b/src/wrappers/glx.rs
@@ -19,10 +19,6 @@ type GlXCreateContextAttribsARB = unsafe extern "C" fn(
     attribs: *const c_int,
 ) -> GLXContext;
 
-/// See https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_swap_control.txt.
-type GlXSwapIntervalEXT =
-    unsafe extern "C" fn(dpy: *mut xlib::Display, drawable: GLXDrawable, interval: i32);
-
 /// See https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_framebuffer_sRGB.txt.
 const GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB: i32 = 0x20B2;
 
@@ -48,7 +44,7 @@ impl Glx {
             GLX_ALPHA_SIZE, config.alpha_bits as i32,
             GLX_DEPTH_SIZE, config.depth_bits as i32,
             GLX_STENCIL_SIZE, config.stencil_bits as i32,
-            GLX_DOUBLEBUFFER, config.double_buffer as i32,
+            GLX_DOUBLEBUFFER, 1,
             GLX_SAMPLE_BUFFERS, config.samples.is_some() as i32,
             GLX_SAMPLES, config.samples.unwrap_or(0) as i32,
             GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB, config.srgb as i32,
@@ -128,13 +124,6 @@ impl Glx {
         NonNull::new(result as *mut c_void)
     }
 
-    pub fn get_glx_swap_interval_ext(&self) -> Option<GlXSwapIntervalEXT> {
-        let ptr = self.get_proc_address(c"glXSwapIntervalEXT")?;
-
-        // SAFETY: NonNull is repr(transparent), GlXSwapIntervalEXT is the correct type for this function pointer
-        Some(unsafe { core::mem::transmute::<NonNull<c_void>, GlXSwapIntervalEXT>(ptr) })
-    }
-
     pub fn get_glx_create_context_attribs_arb(&self) -> Option<GlxCreateContextAttribsARB> {
         let ptr = self.get_proc_address(c"glXCreateContextAttribsARB")?;
 
@@ -168,34 +157,6 @@ impl Glx {
         &self, connection: &XlibConnection, error_handler: &XErrorHandler,
     ) -> Result<()> {
         self.make_current(connection, 0, core::ptr::null_mut(), error_handler)
-    }
-
-    pub unsafe fn with_current_context<T>(
-        &self, connection: &XlibConnection, window_id: c_ulong, context: GLXContext,
-        error_handler: &XErrorHandler, closure: impl FnOnce() -> T,
-    ) -> Result<T> {
-        self.make_current(connection, window_id, context, error_handler)?;
-
-        // Using a "drop" allows us to clear the GL context even if the given closure panics
-        let clearer = ContextClearOnDrop { glx: self, connection, error_handler };
-
-        let result = closure();
-
-        drop(clearer);
-
-        Ok(result)
-    }
-}
-
-pub struct ContextClearOnDrop<'a> {
-    glx: &'a Glx,
-    connection: &'a XlibConnection,
-    error_handler: &'a XErrorHandler<'a>,
-}
-
-impl Drop for ContextClearOnDrop<'_> {
-    fn drop(&mut self) {
-        let _ = unsafe { self.glx.clear_current(self.connection, self.error_handler) };
     }
 }
 

--- a/src/wrappers/win32/window/wgl.rs
+++ b/src/wrappers/win32/window/wgl.rs
@@ -90,9 +90,6 @@ impl Drop for WglContext {
     }
 }
 
-// See https://www.khronos.org/registry/OpenGL/extensions/EXT/WGL_EXT_swap_control.txt
-type WglSwapIntervalEXT = unsafe extern "system" fn(i32) -> i32;
-
 // See https://www.khronos.org/registry/OpenGL/extensions/ARB/WGL_ARB_pixel_format.txt
 type WglChoosePixelFormatARB =
     unsafe extern "system" fn(HDC, *const i32, *const f32, u32, *mut i32, *mut u32) -> i32;
@@ -104,7 +101,6 @@ type WglCreateContextAttribsARB = unsafe extern "system" fn(HDC, HGLRC, *const i
 pub struct WglExtra {
     wglCreateContextAttribsARB: Option<WglCreateContextAttribsARB>,
     wglChoosePixelFormatARB: Option<WglChoosePixelFormatARB>,
-    wglSwapIntervalEXT: Option<WglSwapIntervalEXT>,
 }
 
 impl WglExtra {
@@ -116,9 +112,6 @@ impl WglExtra {
                 ),
                 wglChoosePixelFormatARB: transmute::<PROC, Option<WglChoosePixelFormatARB>>(
                     wglGetProcAddress(s!("wglChoosePixelFormatARB")),
-                ),
-                wglSwapIntervalEXT: transmute::<PROC, Option<WglSwapIntervalEXT>>(
-                    wglGetProcAddress(s!("wglSwapIntervalEXT")),
                 ),
             }
         }
@@ -150,20 +143,6 @@ impl WglExtra {
             NonNull::new(ctx).ok_or_else(|| CreateContextError::Win32(Error::from_thread()))?;
 
         Ok(WglContext { inner: ctx })
-    }
-
-    pub fn set_vsync(&self, vsync: bool) -> windows_core::Result<()> {
-        let Some(wglSwapIntervalEXT) = self.wglSwapIntervalEXT else {
-            warn!("Could not set vsync: wglSwapIntervalEXT is not available");
-            return Ok(());
-        };
-
-        let result = unsafe { wglSwapIntervalEXT(vsync.into()) };
-        if result == 0 {
-            return Err(Error::from_thread());
-        }
-
-        Ok(())
     }
 
     pub fn choose_pixel_format_from_attribs(
@@ -266,7 +245,7 @@ impl PixelFormatAttribs {
                 WGL_DRAW_TO_WINDOW_ARB, 1,
                 WGL_ACCELERATION_ARB, WGL_FULL_ACCELERATION_ARB,
                 WGL_SUPPORT_OPENGL_ARB, 1,
-                WGL_DOUBLE_BUFFER_ARB, config.double_buffer as i32,
+                WGL_DOUBLE_BUFFER_ARB, 1,
                 WGL_PIXEL_TYPE_ARB, WGL_TYPE_RGBA_ARB,
                 WGL_RED_BITS_ARB, config.red_bits as i32,
                 WGL_GREEN_BITS_ARB, config.green_bits as i32,


### PR DESCRIPTION
`vsync` should never be turned on, as it blocks the thread waiting for the next frame (which will also block the host DAW in the plugin case).

Conversely, `double_buffer` is always turned on, so the setting isn't of much use.