### PR TITLE
MacOS: Prevent automatic rescaling on resize events

### DIFF
--- a/src/wrappers/appkit/timer.rs
+++ b/src/wrappers/appkit/timer.rs
@@ -1,7 +1,7 @@
 use block2::RcBlock;
 use objc2::rc::Weak;
 use objc2_core_foundation::{
-    kCFAllocatorDefault, kCFRunLoopDefaultMode, CFRetained, CFRunLoop, CFRunLoopTimer,
+    kCFAllocatorDefault, kCFRunLoopCommonModes, CFRetained, CFRunLoop, CFRunLoopTimer,
     CFTimeInterval,
 };
 
@@ -20,7 +20,7 @@ impl TimerHandle {
         let timer =
             unsafe { CFRunLoopTimer::with_handler(allocator, 0.0, interval, 0, 0, Some(&block)) }?;
 
-        let loop_mode = unsafe { kCFRunLoopDefaultMode };
+        let loop_mode = unsafe { kCFRunLoopCommonModes };
         run_loop.add_timer(Some(&timer), loop_mode);
 
         Some(Self { run_loop: Weak::from_retained(&run_loop.into()), timer })
@@ -33,7 +33,7 @@ impl Drop for TimerHandle {
             return;
         };
 
-        let loop_mode = unsafe { kCFRunLoopDefaultMode };
+        let loop_mode = unsafe { kCFRunLoopCommonModes };
 
         run_loop.remove_timer(Some(&self.timer), loop_mode);
     }


### PR DESCRIPTION
Currently when the window is resized on macOS the UI scales proportionally.
Changing the CFRunLoop from kCFRunLoopDefaultMode to kCFRunLoopCommonModes removes that automatic rescaling behavior. Giving the user control over the scaling.

I came across this in the nice-plug example plugins. The expected behavior for these plugins is to not rescale the UI on resize events. What is actually happening is the UI gets rescaled on resize events and when resizing is finished the scale snaps back to a factor of 1 (the original scale).

